### PR TITLE
React+Reflux async demo

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "auth0-lock": "^7.8.1",
+    "axios": "^0.5.4",
     "babel-runtime": "^5.8.20",
     "ejs": "^2.3.3",
     "express": "~4.13.3",

--- a/frontend/src/actions/actions.js
+++ b/frontend/src/actions/actions.js
@@ -1,9 +1,12 @@
 import Reflux from 'reflux';
 
 
-const Actions = Reflux.createActions({
+export const TestActions = Reflux.createActions({
   // user actions
   'loggedIn': {}
 });
 
-export default Actions;
+export const DashboardActions = Reflux.createActions({
+  'fetchProjects': {asyncResult: true},
+  'createProject': {asyncResult: true}
+});

--- a/frontend/src/components/dashboard/dashboard.jsx
+++ b/frontend/src/components/dashboard/dashboard.jsx
@@ -1,10 +1,51 @@
 import React from 'react/addons';
+import {Navigation} from 'react-router';
+import Reflux from 'reflux';
+import Project from './project.jsx';
+import {DashboardActions as Actions} from '../../actions/actions.js';
+import dashboardStore from '../../stores/dashboardStore.js';
 
 let Dashboard = React.createClass({
-  render: function() {
+  mixins: [Navigation, Reflux.ListenerMixin],
+
+  getInitialState() {
+    return {
+      projects: []
+    };
+  },
+
+  // listen to data changes from `dashboardStore`
+  // `listen` returns a convenient unsubscribe functor
+  componentDidMount() {
+    this.listenTo(dashboardStore, this.onProjectsFetched);
+    Actions.fetchProjects();
+  },
+
+  onProjectsFetched(projects) {
+    this.setState({projects: projects});
+  },
+
+  enterProject(id) {
+    this.transitionTo('overview', {
+      id: id
+    });
+  },
+
+  createProject() {
+    Actions.createProject();
+  },
+
+  render() {
     return (
-      <div>
-        <p>This is the Dashboard!</p>
+      <div className='dashboard'>
+        <ul>
+          <Project key='0' id='0' name='+ New Project' click={this.createProject} />
+          {
+            this.state.projects.map((project) => {
+              return <Project key={project.id} id={project.id} name={project.name}  click={this.enterProject} />;
+            })
+          }
+        </ul>
       </div>
     );
   }

--- a/frontend/src/components/dashboard/project.jsx
+++ b/frontend/src/components/dashboard/project.jsx
@@ -1,0 +1,18 @@
+import React from 'react/addons';
+
+let Project = React.createClass({
+  handleClick() {
+    // this.props.key is not accessible, this is the recommended approach
+    // pass in id as another property
+    this.props.click(this.props.id);
+  },
+  render() {
+    return (
+      <li className='project' onClick={this.handleClick}>
+        <p className='project-name'>{this.props.name}</p>
+      </li>
+    );
+  }
+});
+
+export default Project;

--- a/frontend/src/stores/dashboardStore.js
+++ b/frontend/src/stores/dashboardStore.js
@@ -1,0 +1,58 @@
+import Reflux from 'reflux';
+import axios from 'axios';
+import {DashboardActions as Actions} from '../actions/actions';
+
+axios.interceptors.request.use((config) => {
+  config.headers.Authorization = 'Bearer ' + localStorage.getItem('userToken');
+  config.url = 'http://127.0.0.1:1337'; // project service
+  return config;
+});
+
+let count = 3;
+let mock = [
+  {
+    id: 1,
+    name: 'Greenfield'
+  }, {
+    id: 2,
+    name: 'Legacy'
+  }
+];
+
+let DashboardStore = Reflux.createStore({
+  init() {
+    this.listenTo(Actions.fetchProjects, this.onFetchProjects);
+    this.listenTo(Actions.createProject, this.onCreateProject);
+  },
+  onFetchProjects() {
+    // axios.get('/projects')
+    //   .then((response) => {
+    //     if (response.status === 200) {
+    //       this.trigger(response.data);
+    //     }
+    //   });
+
+    // delete when ready
+    this.trigger(mock);
+  },
+  onCreateProject() {
+    // axios.post('/projects', {
+    //   name: 'my project'
+    // })
+    // .then((response) => {
+    //   if (response.status === 201) {
+    //     Actions.fetchProjects();
+    //   }
+    // });
+
+    // delete when ready
+    mock.push({
+      id: count++,
+      name: 'Thesis'
+    });
+
+    Actions.fetchProjects();
+  }
+});
+
+export default DashboardStore;

--- a/project-service/docs/events.md
+++ b/project-service/docs/events.md
@@ -31,7 +31,7 @@ Project level changes. If there are changes in which users belong to the current
 - **Event Name**
   + `project:change`
 - **Data Parameters**
-  + OPTIONAL
+  + Applicable
     * `name=[string]`
     * `users=[array]`
 - **Example Data**
@@ -71,7 +71,7 @@ New sprint added to current project.
 - **Event Name**
   + `sprint:add`
 -  **Data Parameters**
-  +  ALWAYS
+  +  Always
     *  `id=[number]`
     +  `name=[string]`
     +  `status=[string]`
@@ -100,9 +100,9 @@ Change in a sprint's details for current project.
 - **Event Name**
   + `sprint:change`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
-  + OPTIONAL
+  + Applicable
     *  `name=[string]`
     *  `status=[string]`
     *  `startDate=[date]`
@@ -128,7 +128,7 @@ Sprint deleted from current project.
 - **Event Name**
   + `sprint:delete`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
 - **Example Data**
 
@@ -152,7 +152,7 @@ New task added to current project.
 - **Event Name**
   + `task:add`
 -  **Data Parameters**
-  +  ALWAYS
+  +  Always
     *  `id=[number]`
     +  `name=[string]`
     +  `description=[string]`
@@ -187,9 +187,9 @@ Change in a tasks's details for current project.
 - **Event Name**
   + `task:change`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
-  + OPTIONAL
+  + Applicable
     *  `name=[string]`
     *  `description=[string]`
     *  `status=[string]`
@@ -219,7 +219,7 @@ Task deleted from current project.
 - **Event Name**
   + `task:delete`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
 - **Example Data**
 

--- a/project-service/tests/integration/userSpec.js
+++ b/project-service/tests/integration/userSpec.js
@@ -46,6 +46,28 @@ test('Public API should create a new user for any new valid Authorization header
     });
 });
 
+test('Public API should not create another user for the same Authorization header', (t) => {
+  let params = {
+    where: {
+      auth0Id: profiles[1].user_id
+    }
+  };
+
+  return models.User.findAll(params)
+    .then((users) => {
+      t.equal(users.length, 1, 'Confirm that user is already in database');
+      return request(app)
+        .get('/')
+        .set('Authorization', authorization[1]);
+    })
+    .then(() => {
+      return models.User.findAll(params);
+    })
+    .then((users) => {
+      t.equal(users.length, 1, 'There should still only be one user in database');
+    });
+});
+
 after('After', (t) => {
   return models.sequelize.sync({
     force: true


### PR DESCRIPTION
## DO NOT MERGE - DEMO PURPOSES ONLY
- Ignore the documentation commit. That is cleanup that I will rename later.

This is a quick demo of how I think async calls should work within React + Reflux.
1. User visits Turtle, default route is `Dashboard`
2. `Dashboard` React lifecycle hook `componentDidMount` is called, which does two things:
   - listen to data changes from `DashboardStore` (line 19)
   - invoke the action `fetchProjects` (note that all actions are in `actions.js`, but grouped by major React components and exported separately) (line 20)
3. `DashboardStore` (`dashboardStore.js`) is listening for `fetchProjects` action with `onFetchProjects` as the handler. `onFetchProjects` does an async fetch using axios, and on completion, calls `this.trigger(projects)`. I have placeholder dummy data there right now instead of an actual request.
4. `Dashboard` was listening to any data changes from `DashboardStore`, and calls `this.setState` when it receives updated data. This results in re-render, and the render just displays a list of `Project` components.

![dashboard](https://cloud.githubusercontent.com/assets/10968717/9698196/4751e9ba-5360-11e5-9f10-138697f9bd0d.png)
1. `Dashboard` passes a callback to each `Project` component as a property `click`. This callback is `enterProject`, which takes a projectId as an argument. When a project get's clicked, I want this callback to be invoked. In each `Project` component, there is a button, that when clicked, calls `handleClick`, which calls `this.props.click` (this is whatever `Dashboard` passed in) with the component's `id`.
2. Back in `Dashboard` component, `enterProject` got called, and it transitions to `overview`, passing the projectId as a parameter.
3. `Overview` component does similar things once it is mounted. It listens for data changes from `OverviewStore`, and invokes an action `fetchProjectDetails`, passing in `this.props.params.id` as an argument.
4. `OverviewStore` was listening for that action, and as a result, does an async fetch. It receives the project `id` as an argument, so it can fetch details for the specific project. When complete, does `this.trigger`.
5. `Overview` was listening for data changes, so calls `this.setState` with the fetched data and re-renders itself.

Click project 0:
![proj 0](https://cloud.githubusercontent.com/assets/10968717/9698219/1f712ebe-5361-11e5-808b-f6976d243b97.png)

Click project 1:
![proj 1](https://cloud.githubusercontent.com/assets/10968717/9698240/1fe9ad84-5362-11e5-98a9-419fca601d2c.png)
