### PR TITLE
(build) Added a watchify task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 frontend:
   build: frontend
+  volumes:
+   - frontend:/app
   ports:
     - "8080:80"
   links:
@@ -8,6 +10,8 @@ frontend:
 
 projectservice:
   build: project-service
+  volumes:
+   - project-service:/app
   ports:
    - "3000:80"
   links:
@@ -21,6 +25,8 @@ projectservice:
 
 eventsystem:
   build: event-system
+  volumes:
+   - event-system:/app
   ports:
     - "4000:80"
   links:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian
 
-RUN apt-get update && apt-get -y install curl
+RUN apt-get update && apt-get -y install curl git
 
 # gpg keys listed at https://github.com/nodejs/io.js
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \

--- a/frontend/gulp/browsersync.js
+++ b/frontend/gulp/browsersync.js
@@ -1,15 +1,16 @@
 import gulp from 'gulp';
 import browserSync from 'browser-sync';
 
-gulp.task('frontend:watch', () => {
+gulp.task('frontend:watch', ['watchify'], () => {
   browserSync({
     proxy: {
       target: 'localhost:8080'
-    }
+    },
+    port: 3100,
+    ui: false
   });
 
   gulp.watch(global.paths.styles, ['frontend:watch:css']);
-  gulp.watch(global.paths.js, ['frontend:watch:js']);
   gulp.watch(global.paths.images, ['frontend:watch:img']);
 });
 
@@ -20,5 +21,4 @@ let reload = () => {
 };
 
 gulp.task('frontend:watch:css', ['frontend:build:css'], reload);
-gulp.task('frontend:watch:js', ['frontend:build:js'], reload);
 gulp.task('frontend:watch:img', ['frontend:build:img'], reload);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "csswring": "~3.0.7",
     "ejsify": "^1.0.0",
     "gulp-imagemin": "~2.3.0",
+    "gulp-notify": "~2.2.0",
     "gulp-postcss": "~6.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.2",
@@ -43,6 +44,7 @@
     "postcss-normalize": "~0.1.1",
     "requiredir": "^1.0.7",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.4.0"
   }
 }


### PR DESCRIPTION
Added a 'watchify' task to frontend/gulp/browserify.js

The task dramatically reduces the time to re-bundle the frontend js files (to tens of microseconds).

However, I am not sure how (or whether to) to integrate this with frontend:watch — there is no need to call `watchify` repeatedly after file change; it needs to be called only once
