### PR TITLE
Misc. changes to project service 

### DIFF
--- a/project-service/docs/api.md
+++ b/project-service/docs/api.md
@@ -485,9 +485,9 @@ Delete an existing sprint. tasks that belong to this sprint are **not** deleted.
 Add/remove an array of tasks to a sprint by attaching an array of task IDs with the request. Tasks that don't exist or don't need to be changed will be ignored.
 
 - **URL**
-  + `/projects/:projectId/sprints/:sprintId/tasks`
+  + `/projects/:projectId/sprints/:sprintId/assigntasks`
 - **Method**
-  + `PUT`
+  + `POST`
 - **Query Params**
   + None
 - **Data Params**

--- a/project-service/docs/events.md
+++ b/project-service/docs/events.md
@@ -31,7 +31,7 @@ Project level changes. If there are changes in which users belong to the current
 - **Event Name**
   + `project:change`
 - **Data Parameters**
-  + OPTIONAL
+  + When Applicable
     * `name=[string]`
     * `users=[array]`
 - **Example Data**
@@ -71,7 +71,7 @@ New sprint added to current project.
 - **Event Name**
   + `sprint:add`
 -  **Data Parameters**
-  +  ALWAYS
+  +  Always
     *  `id=[number]`
     +  `name=[string]`
     +  `status=[string]`
@@ -100,9 +100,9 @@ Change in a sprint's details for current project.
 - **Event Name**
   + `sprint:change`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
-  + OPTIONAL
+  + When Applicable
     *  `name=[string]`
     *  `status=[string]`
     *  `startDate=[date]`
@@ -128,7 +128,7 @@ Sprint deleted from current project.
 - **Event Name**
   + `sprint:delete`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
 - **Example Data**
 
@@ -152,7 +152,7 @@ New task added to current project.
 - **Event Name**
   + `task:add`
 -  **Data Parameters**
-  +  ALWAYS
+  +  Always
     *  `id=[number]`
     +  `name=[string]`
     +  `description=[string]`
@@ -187,9 +187,9 @@ Change in a tasks's details for current project.
 - **Event Name**
   + `task:change`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
-  + OPTIONAL
+  + When Applicable
     *  `name=[string]`
     *  `description=[string]`
     *  `status=[string]`
@@ -219,7 +219,7 @@ Task deleted from current project.
 - **Event Name**
   + `task:delete`
 - **Data Parameters**
-  + ALWAYS
+  + Always
     * `id=[number]`
 - **Example Data**
 

--- a/project-service/src/config.js
+++ b/project-service/src/config.js
@@ -1,11 +1,4 @@
 let config = {
-  development: {
-    host: '127.0.0.1',
-    dialect: 'postgres',
-    database: 'turtle',
-    username: 'test',
-    password: ''
-  },
   test: {
     host: '127.0.0.1',
     dialect: 'sqlite',

--- a/project-service/src/routes/sprints.js
+++ b/project-service/src/routes/sprints.js
@@ -43,10 +43,9 @@ router.param('sprintId', (req, res, next, sprintId) => {
 });
 
 // Add/Remove Tasks to/from Sprint
-/* === /projects/:projectId/sprints/:sprintId/tasks === */
+/* === /projects/:projectId/sprints/:sprintId/assigntasks === */
 
-// router.put('/:projectId/sprints/:sprintId/tasks', (req, res, next) => {
-router.put('/:sprintId/tasks', (req, res, next) => {
+router.post('/:sprintId/assigntasks', (req, res, next) => {
   if (!(req.body.add || req.body.remove)) {
     return res.status(400).json(msg.task[400]);
   }

--- a/project-service/tests/sprintSpec.js
+++ b/project-service/tests/sprintSpec.js
@@ -162,7 +162,7 @@ test('DELETE /projects/:projectId/sprints/:sprintId should delete a sprint witho
     });
 });
 
-test('PUT /projects/:projectId/sprints/:sprintId/tasks should add/remove tasks to/from sprint', (t) => {
+test('POST /projects/:projectId/sprints/:sprintId/assigntasks should add/remove tasks to/from sprint', (t) => {
   let taskIds = [];
   let numTasks;
 
@@ -199,7 +199,7 @@ test('PUT /projects/:projectId/sprints/:sprintId/tasks should add/remove tasks t
     .then((sprint) => { // track starting number of tasks in sprint; send request to add tasks
       numTasks = sprint.tasks.length;
       return request(app)
-        .put('/projects/'+projectId+'/sprints/'+sprintIds[0]+'/tasks')
+        .post('/projects/'+projectId+'/sprints/'+sprintIds[0]+'/assigntasks')
         .set('Authorization', authorization(0))
         .send({add: taskIds})
         .expect(204);
@@ -211,7 +211,7 @@ test('PUT /projects/:projectId/sprints/:sprintId/tasks should add/remove tasks t
     .then((sprint) => { // confirm # tasks in sprint, and send request to remove tasks
       t.equal(sprint.tasks.length, numTasks + taskIds.length, 'Tasks should be assigned to sprint');
       return request(app)
-        .put('/projects/'+projectId+'/sprints/'+sprintIds[0]+'/tasks')
+        .post('/projects/'+projectId+'/sprints/'+sprintIds[0]+'/assigntasks')
         .set('Authorization', authorization(0))
         .send({remove: taskIds})
         .expect(204);

--- a/project-service/tests/userSpec.js
+++ b/project-service/tests/userSpec.js
@@ -46,6 +46,28 @@ test('Public API should create a new user for any new valid Authorization header
     });
 });
 
+test('Public API should not create another user for the same Authorization header', (t) => {
+  let params = {
+    where: {
+      auth0Id: profile(1).user_id
+    }
+  };
+
+  return models.User.findAll(params)
+    .then((users) => {
+      t.equal(users.length, 1, 'Confirm that user is already in database');
+      return request(app)
+        .get('/')
+        .set('Authorization', authorization(1));
+    })
+    .then(() => {
+      return models.User.findAll(params);
+    })
+    .then((users) => {
+      t.equal(users.length, 1, 'There should still only be one user in database');
+    });
+});
+
 after('After', (t) => {
   return models.sequelize.sync({
     force: true


### PR DESCRIPTION
- Renamed bulk add/remove tasks endpoint

from

> /projects/:projectId/sprints/:sprintId/**tasks**

to

> /projects/:projectId/sprints/:sprintId/**assigntasks**

and changed HTTP method from `PUT` to `POST`
- Updated API docs accordingly
- Minor edits to the Events doc
- New test to ensure duplicate users are not created for the same Authorization header
