### PR TITLE
(feat) Add dashboard view

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,10 +17,13 @@
     "auth0-lock": "^7.8.1",
     "axios": "^0.5.4",
     "babel-runtime": "^5.8.20",
+    "bootstrap": "^3.3.5",
+    "classnames": "^2.1.3",
     "ejs": "^2.3.3",
     "express": "~4.13.3",
     "lodash": "^3.10.1",
     "react": "^0.13.3",
+    "react-bootstrap": "^0.25.1",
     "react-router": "^0.13.3",
     "reflux": "^0.2.12"
   },

--- a/frontend/src/actions/actions.js
+++ b/frontend/src/actions/actions.js
@@ -1,9 +1,6 @@
 import Reflux from 'reflux';
 
-
-const Actions = Reflux.createActions({
-  // user actions
-  'loggedIn': {}
+export const DashboardActions = Reflux.createActions({
+  'fetchProjects': {asyncResult: true},
+  'createProject': {asyncResult: true}
 });
-
-export default Actions;

--- a/frontend/src/components/dashboard/createProject.jsx
+++ b/frontend/src/components/dashboard/createProject.jsx
@@ -1,0 +1,113 @@
+import React from 'react/addons';
+import {Modal} from 'react-bootstrap';
+import Member from './member.jsx';
+import {DashboardActions as Actions} from '../../actions/actions.js';
+
+let CreateProject = React.createClass({
+  getInitialState() {
+    return {
+      invitees: [],
+      inviteeEmail: '',
+      disableInvite: true,
+      disableCreate: true
+    };
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevProps.showModal && this.props.showModal) {
+      React.findDOMNode(this.refs.projectName).focus();
+    }
+  },
+
+  checkEmail(e) {
+    // consider replacing this with proper email validation
+    this.setState({
+      disableInvite: !e.target.value,
+      inviteeEmail: e.target.value
+    });
+  },
+
+  invite() {
+    let email = React.findDOMNode(this.refs.inviteeEmail).value;
+    if (email) {
+      let invitees = this.state.invitees.slice();
+      invitees.push({email: email});
+      this.setState({
+        invitees: invitees,
+        inviteeEmail: '',
+        disableInvite: true
+      });
+    }
+  },
+
+  removeInvite(index) {
+    let invitees = this.state.invitees.slice();
+    invitees.splice(index, 1);
+    this.setState({invitees: invitees});
+  },
+
+  checkName(e) {
+    this.setState({disableCreate: !e.target.value});
+  },
+
+  createProject() {
+    let name = React.findDOMNode(this.refs.projectName).value;
+    if (name) {
+      Actions.createProject(name);
+      this.props.close();
+    }
+  },
+
+  render() {
+    let nameSection = (
+      <section className='create-name'>
+        <h3>Project Name</h3>
+        <input type='text' ref='projectName' placeholder='Ex. Turtle' onChange={this.checkName} />
+      </section>
+    );
+
+    let inviteSection = (
+      <section className='create-invite'>
+        <h3>Team Members</h3>
+        <form>
+          <input type='email' ref='inviteeEmail' placeholder='somebody@turtle.com' onChange={this.checkEmail} value={this.state.inviteeEmail} />
+          <button className='btn' onClick={this.invite} disabled={this.state.disableInvite}>Invite</button>
+        </form>
+      </section>
+    );
+
+    let inviteeList = (
+      <section className='create-invitees'>
+        <ul>
+          {
+            this.state.invitees.map((invitee, idx) => {
+              return <Member key={idx} idx={idx} email={invitee.email} remove={this.removeInvite} />;
+            })
+          }
+        </ul>
+      </section>
+    );
+
+    return (
+      <Modal show={this.props.showModal} onHide={this.props.close}>
+        <Modal.Header closeButton>
+          <Modal.Title>Create a New Project</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          {nameSection}
+          {inviteSection}
+          {(() => {
+            return this.state.invitees.length ? inviteeList : undefined;
+          })()}
+        </Modal.Body>
+
+        <Modal.Footer>
+          <button className='btn' onClick={this.createProject} disabled={this.state.disableCreate}>Create</button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+});
+
+export default CreateProject;

--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -1,0 +1,78 @@
+.dashboard {
+  text-align: center;
+  width: 850px;
+  margin: 30px auto;
+}
+
+.item {
+  cursor: pointer;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  line-height: 200px;
+  border: 1px solid black;
+  border-radius: 4px;
+  margin: 20px;
+  .name {
+    display: inline-block;
+    line-height: 20px;
+    vertical-align: middle;
+  }
+}
+
+.project-create {
+  color: #aaa;
+  border: 1px solid #cdcdcd;
+}
+
+.modal-header {
+  text-align: center;
+}
+
+.modal-body {
+  text-align: center;
+  padding: 0 15%;
+}
+
+.create-name {
+  height: 70px;
+}
+
+.create-invite {
+  padding: 0 16px;
+  margin: 10px auto;
+  height: 80px;
+  input {
+    width: 55%;
+    float: left;
+  }
+}
+
+.create-invitees {
+  padding: 10px 16px 0px;
+  margin: 10px auto 10px auto;
+  max-height: 215px;
+  overflow: auto;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  ul {
+    padding: 0;
+  }
+  .member {
+    display: block;
+    list-style-type: none;
+    overflow: auto;
+    clear: both;
+    margin: 4px 0;
+    .email {
+      float: left;
+    }
+  }
+}
+
+.modal-footer {
+  text-align: center;
+  .btn {
+    float: none;
+  }
+}

--- a/frontend/src/components/dashboard/dashboard.jsx
+++ b/frontend/src/components/dashboard/dashboard.jsx
@@ -1,10 +1,56 @@
 import React from 'react/addons';
+import {Navigation} from 'react-router';
+import Reflux from 'reflux';
+import Item from './item.jsx';
+import CreateProject from './createProject.jsx';
+import {DashboardActions as Actions} from '../../actions/actions.js';
+import dashboardStore from '../../stores/dashboardStore.js';
 
 let Dashboard = React.createClass({
-  render: function() {
+  // `ListenerMixin` will unsubscribe components from stores upon unmounting
+  mixins: [Navigation, Reflux.ListenerMixin],
+
+  getInitialState() {
+    return {
+      projects: [],
+      showModal: false
+    };
+  },
+
+  componentDidMount() {
+    this.listenTo(dashboardStore, this.onProjectsFetched);
+    Actions.fetchProjects();
+  },
+
+  onProjectsFetched(projects) {
+    this.setState({projects: projects});
+  },
+
+  enterProject(id) {
+    this.transitionTo('project', {id: id});
+  },
+
+  close() {
+    this.setState({showModal: false});
+  },
+
+  open() {
+    this.setState({showModal: true});
+  },
+
+  render() {
     return (
-      <div>
-        <p>This is the Dashboard!</p>
+      <div className='dashboard'>
+        <CreateProject showModal={this.state.showModal} close={this.close}/>
+
+        <ul>
+          <Item id='0' name='+ New Project' click={this.open} isCreateProject='true'/>
+          {
+            this.state.projects.map((project) => {
+              return <Item key={project.id} id={project.id} name={project.name} click={this.enterProject} />;
+            })
+          }
+        </ul>
       </div>
     );
   }

--- a/frontend/src/components/dashboard/item.jsx
+++ b/frontend/src/components/dashboard/item.jsx
@@ -1,0 +1,23 @@
+import React from 'react/addons';
+import classNames from 'classnames';
+
+let Item = React.createClass({
+  handleClick() {
+    // this.props.key is not accessible, this is the recommended approach
+    // pass in id as another property
+    this.props.click(this.props.id);
+  },
+  render() {
+    let classes = classNames({
+      'item': true,
+      'project-create': this.props.isCreateProject
+    });
+    return (
+      <li className={classes} onClick={this.handleClick}>
+        <p className='name'>{this.props.name}</p>
+      </li>
+    );
+  }
+});
+
+export default Item;

--- a/frontend/src/components/dashboard/member.jsx
+++ b/frontend/src/components/dashboard/member.jsx
@@ -1,0 +1,19 @@
+import React from 'react/addons';
+
+let Member = React.createClass({
+  handleClick() {
+    // this.props.key is not accessible, this is the recommended approach
+    // pass in id as another property
+    this.props.remove(this.props.idx);
+  },
+  render() {
+    return (
+      <li className='member'>
+        <span className='email'>{this.props.email}</span>
+        <button className='btn' onClick={this.handleClick}>Remove</button>
+      </li>
+    );
+  }
+});
+
+export default Member;

--- a/frontend/src/components/project/backlog.jsx
+++ b/frontend/src/components/project/backlog.jsx
@@ -5,7 +5,7 @@ let Backlog = React.createClass({
 
   render() {
     let tasks = this.props.tasks.map((task) => {
-      return (<Task name={task.name} description={task.description} score={task.score} />);
+      return (<Task key={task.id} id={task.id} name={task.name} description={task.description} score={task.score} />);
     });
 
     return (

--- a/frontend/src/components/project/project.jsx
+++ b/frontend/src/components/project/project.jsx
@@ -11,6 +11,11 @@ let Project = React.createClass({
     };
   },
 
+  componentDidMount() {
+    let id = this.props.params.id;
+    // conduct fetch for project details using this projectId
+  },
+
   render() {
     let tasks = this.state.project.tasks;
     return (

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -17,7 +17,7 @@ let routes = (
     <DefaultRoute handler={Home} />
     <Route name='dashboard' handler={Dashboard} />
     <Route name='sprint' handler={SprintBoard} />
-    <Route name='project' handler={Project} />
+    <Route name='project' path='project/:id' handler={Project} />
   </Route>
 );
 

--- a/frontend/src/stores/dashboardStore.js
+++ b/frontend/src/stores/dashboardStore.js
@@ -1,0 +1,22 @@
+import Reflux from 'reflux';
+import projects from '../ajax/projects';
+import {DashboardActions as Actions} from '../actions/actions';
+
+let DashboardStore = Reflux.createStore({
+  init() {
+    this.listenTo(Actions.fetchProjects, this.onFetchProjects);
+    this.listenTo(Actions.createProject, this.onCreateProject);
+  },
+  onFetchProjects() {
+    projects.fetch().then((projects) => {
+      this.trigger(projects);
+    });
+  },
+  onCreateProject(name) {
+    projects.create({name: name}).then((project) => {
+      Actions.fetchProjects();
+    });
+  }
+});
+
+export default DashboardStore;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -29,5 +29,7 @@ h1 {
   margin-bottom: 10px;
 }
 
+@import "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 @import "components/sprintboard/sprintboard.css";
-@import "components/project/project.css"
+@import "components/project/project.css";
+@import "components/dashboard/dashboard.css";


### PR DESCRIPTION
- Dashboard view
  ![dashboard](https://cloud.githubusercontent.com/assets/10968717/9750792/9c16d1ec-5651-11e5-94d7-db8d52ab43d6.png)
- User can create a new project (bootstrap modal)
  ![create_project](https://cloud.githubusercontent.com/assets/10968717/9750793/a1596976-5651-11e5-9769-8b6173f367b4.png)
- User can invite other users to project (obviously users are not actually added to the project. I only built the mechanism to add emails into an array that can easily be passed along to an action, eventually we'll have it post a request to invitation system)
  ![create_project_2](https://cloud.githubusercontent.com/assets/10968717/9750805/ac8ad492-5651-11e5-94c2-e5c446ad2ab6.png)
- Clicking a project will bring user to `project` view that David created. Though there is that refresh bug I mentioned last time. I'll look into how to fix or work around that.

Closes #47 
