### PR TITLE
Add "Create Task" window

### DIFF
--- a/frontend/src/actions/actions.js
+++ b/frontend/src/actions/actions.js
@@ -5,6 +5,14 @@ export const DashboardActions = Reflux.createActions({
   'createProject': {asyncResult: true}
 });
 
+export const ProjectActions = Reflux.createActions({
+  'fetchProject': {asyncResult: true}
+});
+
+export const CreateTaskActions = Reflux.createActions({
+  'createTask': {asyncResult: true}
+});
+
 export const SprintActions = Reflux.createActions({
   'fetchSprint': {asyncResult: true},
   'updateTaskStatus': {asyncResult: true},

--- a/frontend/src/components/dashboard/createProject.css
+++ b/frontend/src/components/dashboard/createProject.css
@@ -1,0 +1,39 @@
+.create-project {
+  .name {
+    width: 100%;
+    margin: 10px 0;
+  }
+
+  .invitee {
+    width: 100%;
+    margin: 10px 0;
+  }
+
+  .team {
+    margin-top: 15px;
+  }
+
+  .members {
+    margin: 14px 0;
+    padding: 0 10px;
+    max-height: 215px;
+    overflow: auto;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    ul {
+      padding: 0;
+    }
+  }
+
+  .member {
+    display: block;
+    list-style-type: none;
+    clear:both;
+    overflow: auto;
+    margin: 4px 0;
+    line-height: 30px;
+    .email {
+      float: left;
+    }
+  }
+}

--- a/frontend/src/components/dashboard/createProject.jsx
+++ b/frontend/src/components/dashboard/createProject.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
+import {Modal, Input} from 'react-bootstrap';
 import Member from './member.jsx';
 import {DashboardActions as Actions} from '../../actions/actions.js';
 
@@ -28,7 +28,9 @@ let CreateProject = React.createClass({
   },
 
   invite() {
-    let email = React.findDOMNode(this.refs.inviteeEmail).value;
+    // let email = React.findDOMNode(this.refs.inviteeEmail).value;
+    let email = this.refs.inviteeEmail.getValue();
+    console.log(email);
     if (email) {
       let invitees = this.state.invitees.slice();
       invitees.push({email: email});
@@ -53,57 +55,92 @@ let CreateProject = React.createClass({
   createProject() {
     let name = React.findDOMNode(this.refs.projectName).value;
     if (name) {
-      Actions.createProject(name);
-      this.props.close();
+      Actions.createProject(name, (response) => { // check `response.error` for error
+        this.close();
+      });
     }
   },
 
+  close() {
+    this.props.close();
+    this.setState(this.getInitialState());
+  },
+
   render() {
-    let nameSection = (
-      <section className='create-name'>
-        <h3>Project Name</h3>
-        <input type='text' ref='projectName' placeholder='Ex. Turtle' onChange={this.checkName} />
-      </section>
-    );
-
-    let inviteSection = (
-      <section className='create-invite'>
-        <h3>Team Members</h3>
-        <form>
-          <input type='email' ref='inviteeEmail' placeholder='somebody@turtle.com' onChange={this.checkEmail} value={this.state.inviteeEmail} />
-          <button className='btn' onClick={this.invite} disabled={this.state.disableInvite}>Invite</button>
-        </form>
-      </section>
-    );
-
     let inviteeList = (
-      <section className='create-invitees'>
+      <div className='members'>
         <ul>
           {
             this.state.invitees.map((invitee, idx) => {
-              return <Member key={idx} idx={idx} email={invitee.email} remove={this.removeInvite} />;
+              return (
+                <Member
+                  key={idx}
+                  idx={idx}
+                  email={invitee.email}
+                  remove={this.removeInvite}
+                />
+              );
             })
           }
         </ul>
-      </section>
+      </div>
+    );
+
+    const inviteButton = (
+      <button
+        className='btn'
+        onClick={this.invite}
+        disabled={this.state.disableInvite}
+      >
+        Invite
+      </button>
     );
 
     return (
-      <Modal show={this.props.showModal} onHide={this.props.close}>
+      <Modal show={this.props.showModal} onHide={this.close} bsSize='md'>
         <Modal.Header closeButton>
           <Modal.Title>Create a New Project</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          {nameSection}
-          {inviteSection}
-          {(() => {
-            return this.state.invitees.length ? inviteeList : undefined;
-          })()}
+          <div className='create-project'>
+            <form>
+              <input
+                type='text'
+                className='name'
+                ref='projectName'
+                placeholder='Title'
+                onChange={this.checkName}
+              />
+            </form>
+
+            <form>
+              <label className='team'>Team Members</label>
+              <Input
+                type='email'
+                className='invitee'
+                ref='inviteeEmail'
+                placeholder='Email address'
+                onChange={this.checkEmail}
+                value={this.state.inviteeEmail}
+                buttonAfter={inviteButton}
+              />
+            </form>
+
+            {(() => {
+              return this.state.invitees.length ? inviteeList : undefined;
+            })()}
+          </div>
         </Modal.Body>
 
         <Modal.Footer>
-          <button className='btn' onClick={this.createProject} disabled={this.state.disableCreate}>Create</button>
+          <button
+            className='btn'
+            onClick={this.createProject}
+            disabled={this.state.disableCreate}
+          >
+            Create
+          </button>
         </Modal.Footer>
       </Modal>
     );

--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -20,59 +20,7 @@
   }
 }
 
-.project-create {
+.new-project {
   color: #aaa;
-  border: 1px solid #cdcdcd;
-}
-
-.modal-header {
-  text-align: center;
-}
-
-.modal-body {
-  text-align: center;
-  padding: 0 15%;
-}
-
-.create-name {
-  height: 70px;
-}
-
-.create-invite {
-  padding: 0 16px;
-  margin: 10px auto;
-  height: 80px;
-  input {
-    width: 55%;
-    float: left;
-  }
-}
-
-.create-invitees {
-  padding: 10px 16px 0px;
-  margin: 10px auto 10px auto;
-  max-height: 215px;
-  overflow: auto;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  ul {
-    padding: 0;
-  }
-  .member {
-    display: block;
-    list-style-type: none;
-    overflow: auto;
-    clear: both;
-    margin: 4px 0;
-    .email {
-      float: left;
-    }
-  }
-}
-
-.modal-footer {
-  text-align: center;
-  .btn {
-    float: none;
-  }
+  border-color: #aaa;
 }

--- a/frontend/src/components/dashboard/dashboard.jsx
+++ b/frontend/src/components/dashboard/dashboard.jsx
@@ -3,8 +3,8 @@ import {Navigation} from 'react-router';
 import Reflux from 'reflux';
 import Item from './item.jsx';
 import CreateProject from './createProject.jsx';
-import {DashboardActions as Actions} from '../../actions/actions.js';
-import dashboardStore from '../../stores/dashboardStore.js';
+import {DashboardActions as Actions} from '../../actions/actions';
+import dashboardStore from '../../stores/dashboardStore';
 
 let Dashboard = React.createClass({
   // `ListenerMixin` will unsubscribe components from stores upon unmounting
@@ -18,11 +18,11 @@ let Dashboard = React.createClass({
   },
 
   componentDidMount() {
-    this.listenTo(dashboardStore, this.onProjectsFetched);
+    this.listenTo(dashboardStore, this.onStoreUpdate);
     Actions.fetchProjects();
   },
 
-  onProjectsFetched(projects) {
+  onStoreUpdate(projects) {
     this.setState({projects: projects});
   },
 
@@ -31,6 +31,7 @@ let Dashboard = React.createClass({
   },
 
   close() {
+    Actions.fetchProjects();
     this.setState({showModal: false});
   },
 

--- a/frontend/src/components/dashboard/item.jsx
+++ b/frontend/src/components/dashboard/item.jsx
@@ -10,7 +10,7 @@ let Item = React.createClass({
   render() {
     let classes = classNames({
       'item': true,
-      'project-create': this.props.isCreateProject
+      'new-project': this.props.isCreateProject
     });
     return (
       <li className={classes} onClick={this.handleClick}>

--- a/frontend/src/components/dashboard/member.jsx
+++ b/frontend/src/components/dashboard/member.jsx
@@ -10,7 +10,7 @@ let Member = React.createClass({
     return (
       <li className='member'>
         <span className='email'>{this.props.email}</span>
-        <button className='btn' onClick={this.handleClick}>Remove</button>
+        <button className='btn btn-sm' onClick={this.handleClick}>Remove</button>
       </li>
     );
   }

--- a/frontend/src/components/project/backlog.jsx
+++ b/frontend/src/components/project/backlog.jsx
@@ -1,7 +1,29 @@
 import React from 'react';
 import Task from './task.jsx';
+import CreateTask from '../tasks/createTask.jsx';
+import {ProjectActions as Actions} from '../../actions/actions.js';
 
 let Backlog = React.createClass({
+  propTypes: {
+    projectId: React.PropTypes.number.isRequired,
+    users: React.PropTypes.array.isRequired,
+    tasks: React.PropTypes.array.isRequired
+  },
+
+  getInitialState() {
+    return {
+      showModal: false
+    };
+  },
+
+  close() {
+    Actions.fetchProject(this.props.projectId);
+    this.setState({showModal: false});
+  },
+
+  open() {
+    this.setState({showModal: true});
+  },
 
   render() {
     let tasks = this.props.tasks.map((task) => {
@@ -10,8 +32,17 @@ let Backlog = React.createClass({
 
     return (
       <div className='backlog'>
+        <CreateTask
+          showModal={this.state.showModal}
+          close={this.close}
+          projectId={this.props.projectId}
+          users={this.props.users} // to be updated
+          status='Backlog' // to be updated (?)
+          rank={9999} // to be updated
+        />
+
         <h1>Backlog</h1>
-        <button className='btn'>+ New Task</button>
+        <button className='btn' onClick={this.open}>+ New Task</button>
         <div className='clearfix'></div>
         <div className='tasks'>{tasks}</div>
       </div>

--- a/frontend/src/components/project/project.css
+++ b/frontend/src/components/project/project.css
@@ -4,7 +4,6 @@
 }
 
 .btn {
-  width: 150px;
   float: right;
 }
 

--- a/frontend/src/components/project/project.jsx
+++ b/frontend/src/components/project/project.jsx
@@ -1,28 +1,45 @@
 import React from 'react';
+import Reflux from 'reflux';
+import {Navigation} from 'react-router';
 import Backlog from './backlog.jsx';
 import CreateSprint from './createSprint.jsx';
-import {mockProjects} from '../../../tests/utils/fake.js';
+import {ProjectActions as Actions} from '../../actions/actions';
+import projectStore from '../../stores/projectStore';
+// import {mockProjects} from '../../../tests/utils/fake.js';
 
 let Project = React.createClass({
+  mixins: [Navigation, Reflux.ListenerMixin],
 
   getInitialState() {
     return {
-      project: mockProjects(1, 2, 4)[0]
+      id: parseInt(this.props.params.id),
+      project: {
+        users: [],
+        sprints: [],
+        tasks: []
+      }
     };
   },
 
   componentDidMount() {
-    let id = this.props.params.id;
-    // conduct fetch for project details using this projectId
+    this.listenTo(projectStore, this.onStoreUpdate);
+    Actions.fetchProject(this.state.id);
+  },
+
+  onStoreUpdate(project) {
+    this.setState({project: project});
   },
 
   render() {
-    let tasks = this.state.project.tasks;
     return (
       <div className='project-view'>
         <CreateSprint />
         <hr />
-        <Backlog tasks={tasks} />
+        <Backlog
+          projectId={this.state.id}
+          users={this.state.project.users}
+          tasks={this.state.project.tasks}
+        />
       </div>
     );
   }

--- a/frontend/src/components/tasks/createTask.css
+++ b/frontend/src/components/tasks/createTask.css
@@ -1,0 +1,28 @@
+.create-task {
+  .name {
+    width: 100%;
+    margin: 10px 0;
+  }
+
+  .description {
+    width: 100%;
+    max-width: 100%;
+    margin: 10px 0;
+  }
+
+  .assignment {
+    text-align: left;
+    width: 140px;
+    float:left;
+    margin: 10px 0;
+  }
+
+  .score {
+    width: 50px;
+    float: right;
+    margin: 10px 0;
+    input {
+      margin: 0;
+    }
+  }
+}

--- a/frontend/src/components/tasks/createTask.jsx
+++ b/frontend/src/components/tasks/createTask.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import Reflux from 'reflux';
+import _ from 'lodash';
+import {Modal, Input} from 'react-bootstrap';
+import {CreateTaskActions as Actions} from '../../actions/actions';
+import createTaskStore from '../../stores/createTaskStore';
+
+let CreateTask = React.createClass({
+  mixins: [Reflux.ListenerMixin],
+
+  propTypes: {
+    showModal: React.PropTypes.bool.isRequired,
+    close: React.PropTypes.func.isRequired,
+    projectId: React.PropTypes.number.isRequired,
+    users: React.PropTypes.array.isRequired,
+    status: React.PropTypes.string.isRequired,
+    rank: React.PropTypes.number.isRequired,
+    sprintId: React.PropTypes.number // defaults to null
+  },
+
+  getInitialState() {
+    return {
+      disableCreate: true,
+      taskProperties: {
+        name: '',
+        description: '',
+        status: this.props.status,
+        score: 1,
+        rank: this.props.rank,
+        userId: null,
+        sprintId: this.props.sprintId || null
+      }
+    };
+  },
+
+  componentDidMount() {
+    this.listenTo(createTaskStore, this.onStoreUpdate);
+  },
+
+  onStoreUpdate(response) {
+    if (!response.error) {
+      this.close();
+    }
+  },
+
+  createTask() {
+    Actions.createTask(this.props.projectId, this.state.taskProperties);
+  },
+
+  handleChanges(e) {
+    let newProperties = _.extend({}, this.state.taskProperties);
+    newProperties.name = React.findDOMNode(this.refs.taskName).value;
+    newProperties.description = React.findDOMNode(this.refs.taskDescription).value;
+    // uncomment when ready, or else task will not be accepted by project svc
+    // newProperties.userId = parseInt(this.refs.taskAssignment.getValue()) || null;
+    newProperties.score = Math.max(1, React.findDOMNode(this.refs.taskScore).value);
+
+    this.setState({
+      taskProperties: newProperties,
+      disableCreate: !(newProperties.name && newProperties.score)
+    });
+  },
+
+  close() {
+    this.props.close();
+    this.setState(this.getInitialState());
+  },
+
+  render() {
+
+    return (
+      <Modal show={this.props.showModal} onHide={this.close} bsSize='sm'>
+        <Modal.Header closeButton>
+          <Modal.Title>Create a New Task</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <form className='create-task'>
+            <input
+              type='text'
+              className='name'
+              ref='taskName'
+              placeholder='Title'
+              onChange={this.handleChanges}
+              value={this.state.taskProperties.name}
+            />
+
+            <textarea
+              className='description'
+              ref='taskDescription'
+              placeholder='Enter task description'
+              onChange={this.handleChanges}
+              value={this.state.taskProperties.description}
+            >
+            </textarea>
+
+            <div className='assignment'>
+              <Input
+                type='select'
+                ref='taskAssignment'
+                onChange={this.handleChanges}
+                value={this.state.taskProperties.userId}
+                label='Assign to:'
+              >
+                <option value=''>None</option>
+                {
+                  this.props.users.map((user) => {
+                    return <option key={user.id} value={user.id}>{user.username}</option>;
+                  })
+                }
+              </Input>
+            </div>
+
+            <div className='score'>
+              <label>Score:</label>
+              <input
+                type='number'
+                className='score'
+                ref='taskScore'
+                min='1'
+                onChange={this.handleChanges}
+                value={this.state.taskProperties.score}
+              />
+            </div>
+          </form>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <button
+            className='btn'
+            disabled={this.state.disableCreate}
+            onClick={this.createTask}
+          >
+            Create
+          </button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+});
+
+export default CreateTask;

--- a/frontend/src/stores/createTaskStore.js
+++ b/frontend/src/stores/createTaskStore.js
@@ -1,0 +1,16 @@
+import Reflux from 'reflux';
+import projects from '../ajax/projects';
+import {CreateTaskActions as Actions} from '../actions/actions';
+
+let CreateTaskStore = Reflux.createStore({
+  listenables: Actions,
+
+  onCreateTask(id, properties) {
+    console.log(id, properties);
+    projects.id(id).tasks.create(properties).then((response) => {
+      this.trigger(response);
+    });
+  }
+});
+
+export default CreateTaskStore;

--- a/frontend/src/stores/dashboardStore.js
+++ b/frontend/src/stores/dashboardStore.js
@@ -3,18 +3,16 @@ import projects from '../ajax/projects';
 import {DashboardActions as Actions} from '../actions/actions';
 
 let DashboardStore = Reflux.createStore({
-  init() {
-    this.listenTo(Actions.fetchProjects, this.onFetchProjects);
-    this.listenTo(Actions.createProject, this.onCreateProject);
-  },
+  listenables: Actions,
+
   onFetchProjects() {
     projects.fetch().then((projects) => {
       this.trigger(projects);
     });
   },
-  onCreateProject(name) {
-    projects.create({name: name}).then((project) => {
-      Actions.fetchProjects();
+  onCreateProject(name, cb) {
+    projects.create({name: name}).then((response) => {
+      cb(response);
     });
   }
 });

--- a/frontend/src/stores/projectStore.js
+++ b/frontend/src/stores/projectStore.js
@@ -1,0 +1,15 @@
+import Reflux from 'reflux';
+import projects from '../ajax/projects';
+import {ProjectActions as Actions} from '../actions/actions';
+
+let ProjectStore = Reflux.createStore({
+  listenables: Actions,
+
+  onFetchProject(id) {
+    projects.id(id).fetch().then((project) => {
+      this.trigger(project);
+    });
+  }
+});
+
+export default ProjectStore;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,3 +1,5 @@
+@import "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+
 * {
   box-sizing: border-box;
 }
@@ -19,10 +21,15 @@ html, body {
 }
 
 .btn {
+  color: white;
   background: #277DB3;
-  border: 1px solid black;
   border-radius: 5px;
-  padding: 10px;
+}
+
+.btn:hover,
+.btn:focus {
+  color: white;
+  background: #17466C;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -33,7 +40,33 @@ h1 {
   margin-bottom: 10px;
 }
 
-@import "../node_modules/bootstrap/dist/css/bootstrap.min.css";
+input,
+textarea {
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* bootstrap modals */
+.modal-header {
+  text-align: center;
+}
+
+.modal-body {
+  text-align: center;
+  padding: 0 15%;
+}
+
+.modal-footer {
+  clear: both;
+  text-align: center;
+  .btn {
+    float: none;
+  }
+}
+
 @import "components/sprintboard/sprintboard.css";
 @import "components/project/project.css";
 @import "components/dashboard/dashboard.css";
+@import "components/dashboard/createProject.css";
+@import "components/tasks/createTask.css";

--- a/project-service/docs/api.md
+++ b/project-service/docs/api.md
@@ -575,7 +575,7 @@ Get all existing tasks for a project. Tasks are ordered ascending by `rank`.
 <a name="external-tasks-create"/>
 ### Create Task for Project
 
-Create a new task for a project.
+Create a new task for a project. Empty string is allowed for `description`.
 
 - **URL**
   + `/projects/:projectId/tasks`


### PR DESCRIPTION
- Fixed some styling of modals to make it look nicer and more consistent.
- Added `CreateTask` component. It needs to be provided with properties in order to properly create through project service. Currently only linked up to project view, but should be useable in sprintboard view too.
  - project id
  - users
  - default status (e.g. in sprintboard, this would be 'To Do')
  - default rank (e.g. in sprintboard, whatever rank would send this to the bottom?)
  - optional sprint id (e.g. in sprintboard, this should be provided)
- Create new task:
  ![task_0](https://cloud.githubusercontent.com/assets/10968717/9780241/32b53668-573b-11e5-810e-98fb360960ac.png)
- Better looking create new project modal:
  ![proj_3](https://cloud.githubusercontent.com/assets/10968717/9780238/2ce6cb48-573b-11e5-9e4f-11882e4f75e5.png)

Closes #69 
