### PR TITLE
Modify project service API

### DIFF
--- a/project-service/docs/api.md
+++ b/project-service/docs/api.md
@@ -102,7 +102,7 @@ Get all existing projects for a user (as identified through JWT).
 <a name="external-projects-create"/>
 ### Create Project for User
 
-Create a new project for a user (as identified through JWT). Valid emails that correspond to existing users will be sent to the invitation service for handling. The `emails` array can be empty if no additional users are to be invited.
+Create a new project for a user (as identified through JWT). Valid emails that correspond to existing users will be sent to the invitation service for handling.
 
 The `length` is the duration of each sprint, defaults to 7 days.
 
@@ -117,8 +117,8 @@ A sprint is created by default with `status = 0` (planning). The sprint will hav
 - **Data Params**
   + Required
     * `name=[string]`
-    * `emails=[array]`
   + Optional
+    * `emails=[array]`
     * `length=[number]`
 - **Success Response**
   + Code: `201 CREATED`

--- a/project-service/src/models/project.js
+++ b/project-service/src/models/project.js
@@ -1,7 +1,26 @@
 export default (sequelize, DataTypes) => {
   let Project = sequelize.define('Project', {
     name: {
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      validate: {
+        notEmpty: true
+      }
+    },
+    length: {
+      type: DataTypes.INTEGER,
+      defaultValue: 7,
+      allowNull: false,
+      validate: {
+        min: 1
+      }
+    },
+    columns: {
+      type: DataTypes.INTEGER,
+      defaultValue: 4,
+      allowNull: false,
+      validate: {
+        min: 4
+      }
     }
   }, {
     classMethods: {

--- a/project-service/src/models/sprint.js
+++ b/project-service/src/models/sprint.js
@@ -1,10 +1,17 @@
 export default (sequelize, DataTypes) => {
   let Sprint = sequelize.define('Sprint', {
     name: {
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      defaultValue: '',
+      allowNull: false
     },
     status: {
-      type: DataTypes.STRING
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+      allowNull: false,
+      validate: {
+        isIn: [[0, 1, 2]]
+      }
     },
     startDate: {
       type: DataTypes.DATE

--- a/project-service/src/models/task.js
+++ b/project-service/src/models/task.js
@@ -1,19 +1,39 @@
 export default (sequelize, DataTypes) => {
   let Task = sequelize.define('Task', {
     name: {
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      validate: {
+        notEmpty: true
+      }
     },
     description: {
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      defaultValue: ''
     },
     status: {
-      type: DataTypes.STRING
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+      allowNull: false,
+      validate: {
+        min: 0
+      }
     },
     score: {
-      type: DataTypes.INTEGER
+      type: DataTypes.INTEGER,
+      defaultValue: 1,
+      allowNull: false,
+      validate: {
+        min: 1,
+        max: 999
+      }
     },
-    rank: {
-      type: DataTypes.INTEGER
+    order: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1,
+      allowNull: false,
+      validate: {
+        min: 1
+      }
     }
   }, {
     classMethods: {

--- a/project-service/src/models/user.js
+++ b/project-service/src/models/user.js
@@ -1,12 +1,25 @@
 export default (sequelize, DataTypes) => {
   let User = sequelize.define('User', {
     auth0Id: { // unique id (user_id from decoded JWT) provided by Auth0
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      unique: true,
+      allowNull: false
     },
     email: { // email from decoded JWT provided by Auth0
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      unique: true,
+      validate: {
+        isEmail: true,
+        notEmpty: true
+      }
     },
-    username: {
+    username: { // nickname from Auth0
+      type: DataTypes.STRING,
+      validate: {
+        notEmpty: true
+      }
+    },
+    picture: { // picture url from Auth0
       type: DataTypes.STRING
     }
   }, {

--- a/project-service/src/routes/projects.js
+++ b/project-service/src/routes/projects.js
@@ -5,6 +5,7 @@ import models from '../models';
 // for URLs
 // /projects/
 // /projects/:projectId
+// /projects/:projectId/users
 
 let router = express.Router();
 
@@ -17,22 +18,21 @@ let msg = {
     400: {error: 'Invalid data parameters.'},
     404: {error: "Project doesn't exist."},
     405: {error: 'Use GET for project details, PUT to modify, and DELETE to delete.'}
+  },
+  users: { // /projects/:projectId/assignusers
+    405: {error: 'Use POST to assign or remove users from project.'}
   }
 };
 
 // verifies projectId in database and saves to req.project
-// the project must also include user that is sending the request
+// only search projects that include the user sending the request
 export const validation = (req, res, next, projectId) => {
   models.Project.findOne({
-    where: {
-      id: projectId
-    },
+    where: {id: projectId},
     include: [{
       model: models.User,
       as: 'users',
-      where: {
-        id: req.user.model.id
-      }
+      where: {id: req.user.model.id}
     }]
   })
   .then((project) => {
@@ -101,51 +101,54 @@ router.get('/:projectId', (req, res, next) => {
   models.Project.findOne({ // new query with eager loading
     where: {id: req.project.id},
     include: [
-      {
-        model: models.User,
-        as: 'users'
-      }, {
-        model: models.Sprint,
-        as: 'sprints'
-      }, {
-        model: models.Task,
-        as: 'tasks'
-      }
+      {model: models.User, as: 'users'},
+      {model: models.Sprint, as: 'sprints'},
+      {model: models.Task, as: 'tasks'}
     ],
-    order: [ // sort sprints ascending by start date, tasks ascending by `rank`
+    order: [
       [
-        {
-          model: models.Sprint,
-          as: 'sprints'
-        },
-        'startDate',
-        'ASC'
-      ], [
-        {
-          model: models.Task,
-          as: 'tasks'
-        },
-        'rank',
+        {model: models.Task, as: 'tasks'},
+        'order',
         'ASC'
       ]
     ]
   })
   .then((project) => {
-    project = project.dataValues;
+    // only retain underlying data from database for response
     project.users = R.pluck('dataValues')(project.users);
     project.sprints = R.pluck('dataValues')(project.sprints);
     project.tasks = R.pluck('dataValues')(project.tasks);
-    res.status(200).json(project);
+
+    // determine the ongoing and planning phase sprints
+    let currentSprint = R.find(R.propEq('status', 1))(project.sprints);
+    let nextSprint = R.find(R.propEq('status', 0))(project.sprints);
+
+    if (currentSprint) { // if there is an ongoing sprint at the moment
+      currentSprint.tasks = R.filter(R.propEq('sprintId', currentSprint.id))(project.tasks);
+    }
+    nextSprint.tasks = R.filter(R.propEq('sprintId', nextSprint.id))(project.tasks);
+    let backlog = R.filter(R.propEq('sprintId', null))(project.tasks);
+
+    res.status(200).json({
+      id: project.id,
+      name: project.name,
+      length: project.length,
+      users: project.users,
+      currentSprint,
+      nextSprint,
+      backlog
+    });
   });
 });
 
 router.put('/:projectId', (req, res, next) => {
-  if (!req.body.name) {
+  if (!(req.body.name || req.body.length)) {
     return res.status(400).json(msg.project[400]);
   }
 
   req.project.update({
-    name: req.body.name
+    name: req.body.name || req.project.getDataValue('name'),
+    length: req.body.length || req.project.getDataValue('length')
   })
   .then((project) => {
     res.status(200).json(project.dataValues);
@@ -159,31 +162,80 @@ router.delete('/:projectId', (req, res, next) => {
     });
 });
 
-router.all('/:projectId', (req, res, next) => {
-  res.status(405).json(msg.project[405]);
-});
+// Reorder Tasks
+/* === /projects/:projectId/positions === */
 
-// Fetch/Create User's Projects
-/* === /projects === */
+router.post('/:projectId/positions', (req, res, next) => {
+  if (!Array.isArray(req.body.positions)) {
+    return res.status(400).json(msg.project[400]);
+  }
 
-router.get('/', (req, res, next) => {
-  req.user.model.getProjects()
-    .then((projects) => {
-      res.status(200).json(R.pluck('dataValues')(projects));
+  // fetch all backlog tasks
+  req.project.getTasks({where: {sprintId: null}})
+    .then((tasks) => {
+      // create tasks hash
+      let tasksHash = tasks.reduce((hash, task) => {
+        hash[task.id] = task;
+        return hash;
+      }, {});
+
+      // create positions hash -
+      // - the order to be assigned to the task is the index + 1
+      // - only add to hash if the id corresponds to an existing task
+      let posHash = req.body.positions.reduce((hash, id, idx) => {
+        if (tasksHash[id]) {
+          hash[id] = idx + 1;
+        }
+        return hash;
+      }, {});
+
+      // both hashes should have the same number of tasks, otherwise it means
+      // the `positions` array did not have all the backlog tasks
+      if (Object.keys(tasksHash).length !== Object.keys(posHash).length) {
+        return res.status(400).json(msg.project[400]);
+      }
+
+      // update each task's `order` and send success response
+      Promise.all(req.body.positions.map((id) => {
+        return tasksHash[id].update({order: posHash[id]});
+      }))
+      .then((tasks) => {
+        let data = R.pluck('dataValues')(tasks).sort((a, b) => {
+          return a.order - b.order;
+        });
+        res.status(200).json(data);
+      });
     });
 });
 
-router.post('/', (req, res, next) => {
-  if (!req.body.name) {
-    return res.status(400).json(msg.projects[400]);
+// Add/Remove Users
+/* === /projects/:projectId/assignusers === */
+
+router.post('/:projectId/assignusers', (req, res, next) => {
+  req.body.add = req.body.add || [];
+  req.body.remove = req.body.remove || [];
+
+  if (!(Array.isArray(req.body.add) && Array.isArray(req.body.remove))) {
+    return res.status(400).json(msg.project[400]);
   }
 
-  req.user.model.createProject({
-    name: req.body.name
-  })
-  .then((project) => {
-    res.status(201).json(project.dataValues);
+  Promise.all([
+    req.project.addUsers(req.body.add),
+    req.project.removeUsers(req.body.remove)
+  ])
+  .then(() => {
+    res.sendStatus(204);
   });
+});
+
+
+// Catch
+router.all('/:projectId/assignusers', (req, res, next) => {
+  res.status(405).json(msg.users[405]);
+});
+
+router.all('/:projectId', (req, res, next) => {
+  res.status(405).json(msg.project[405]);
 });
 
 router.all('/', (req, res, next) => {

--- a/project-service/src/routes/users.js
+++ b/project-service/src/routes/users.js
@@ -14,7 +14,8 @@ router.use((req, res, next) => {
   .spread((user, created) => { // created = true if a new user was created
     return user.update({
       email: req.user.email,
-      username: req.user.nickname
+      username: req.user.nickname,
+      picture: req.user.picture
     });
   })
   .then((user) => {

--- a/project-service/tests/authSpec.js
+++ b/project-service/tests/authSpec.js
@@ -5,8 +5,9 @@ import app from '../src/app';
 import models from '../src/models';
 
 const before = test;
+const after = test;
 
-before('Before', (t) => {
+before('Before - Auth Spec', (t) => {
   // sync returns a promise
   return models.sequelize.sync();
 });
@@ -28,4 +29,10 @@ test('Public API should respond with 404 when no route is found', (t) => {
     .then((res) => {
       t.pass('404 NOT FOUND'); // t.equal(404, res.status);
     });
+});
+
+after('After - Auth Spec', (t) => {
+  return models.sequelize.sync({
+    force: true
+  });
 });

--- a/project-service/tests/projectSpec.js
+++ b/project-service/tests/projectSpec.js
@@ -2,7 +2,7 @@ import request from 'supertest-as-promised';
 import test from 'blue-tape';
 import R from 'ramda';
 import {authorization, profile} from '../../tests/fakeauth';
-import { projects as testProjects } from '../../tests/fixtures';
+import {projects as testProjects, sprints as testSprints, tasks as testTasks} from '../../tests/fixtures';
 import app from '../src/app';
 import models from '../src/models';
 
@@ -11,7 +11,7 @@ const after = test;
 
 let projectIds;
 
-before('Before', (t) => {
+before('Before - Project Spec', (t) => {
   return models.sequelize.sync({
     force: true
   })
@@ -38,6 +38,24 @@ before('Before', (t) => {
   })
   .then((projects) => {
     projectIds = R.pluck('id')(projects);
+    return Promise.all([
+      projects[0].createSprint(testSprints[1]), // create the "planning" sprint
+      projects[0].createTask(testTasks[0]),
+      projects[0].createTask(testTasks[1]),
+      projects[0].createTask(testTasks[2]),
+      projects[0].createTask(testTasks[3]),
+      projects[0].createTask(testTasks[4])
+    ]);
+  })
+  .then((results) => {
+    let tasks = results.slice(1);
+    return Promise.all([
+      tasks[0].update({order: 1}),
+      tasks[1].update({order: 5}),
+      tasks[2].update({order: 3}),
+      tasks[3].update({order: 4}),
+      tasks[4].update({order: 2})
+    ]);
   });
 });
 
@@ -50,6 +68,8 @@ test("GET /projects should respond with user's projects", (t) => {
       t.pass('200 OK');
       t.assert(Array.isArray(res.body), 'Response should be an array');
       t.equal(res.body[0].name, testProjects[0].name, 'Project name should match');
+      t.assert(res.body[0].length, 'Project should have a length property');
+      t.equal(res.body[0].columns, 4, 'Project should have a columns property = 4');
       return res;
     });
 });
@@ -61,14 +81,39 @@ test('POST /projects should create a new project', (t) => {
     .send(testProjects[1])
     .expect(201)
     .then((res) => {
+      let project = res.body;
       t.pass('201 CREATED');
-      t.equal(res.body.name, testProjects[1].name, 'Project name should match');
+      t.equal(project.name, testProjects[1].name, 'Project name should match');
+      return models.Sprint.findOne({where: {projectId: project.id}});
+    })
+    .then((sprint) => {
+      t.assert(sprint, 'The new project should have a sprint');
+      t.equal(sprint.status, 0, 'The sprint should have status = 0');
+    });
+});
+
+test('POST /projects should still create a new project if missing emails list', (t) => {
+  return request(app)
+    .post('/projects')
+    .set('Authorization', authorization(0))
+    .send({name: 'test'})
+    .expect(201)
+    .then((res) => {
+      let project = res.body;
+      t.pass('201 CREATED');
+      return models.Project.findOne({where: {id: project.id}});
+    })
+    .then((project) => {
+      return project.getUsers();
+    })
+    .then((users) => {
+      t.equal(users.length, 1, 'Only one user should belong to project');
     });
 });
 
 test('GET /projects/:projectId should respond with 404 when projectId does not exist', (t) => {
   return request(app)
-    .get('/projects/5') // some invalid projectId
+    .get('/projects/7') // some invalid projectId
     .set('Authorization', authorization(0))
     .expect(404)
     .then((res) => {
@@ -78,7 +123,7 @@ test('GET /projects/:projectId should respond with 404 when projectId does not e
 
 test('GET /projects/:projectId should respond with 404 if projectId exists but does not belong to user', (t) => {
   return request(app)
-    .get('/projects/'+projectIds[2]) // project that belongs to another user
+    .get(`/projects/${projectIds[2]}`) // project that belongs to another user
     .set('Authorization', authorization(0))
     .expect(404)
     .then((res) => {
@@ -88,25 +133,28 @@ test('GET /projects/:projectId should respond with 404 if projectId exists but d
 
 test('GET /projects/:projectId should respond with project details', (t) => {
   return request(app)
-    .get('/projects/'+projectIds[0])
+    .get(`/projects/${projectIds[0]}`)
     .set('Authorization', authorization(0))
     .expect(200)
     .then((res) => {
       let project = res.body;
       t.pass('200 OK');
-      t.assert(project.hasOwnProperty('users'), 'Project details should include users');
-      t.assert(project.hasOwnProperty('sprints'), 'Project details should include sprints');
-      t.assert(project.hasOwnProperty('tasks'), 'Project details should include tasks');
+      t.assert(project.users, 'Project details should include users');
+      t.assert(project.nextSprint, 'Project details should include next sprint (planning)');
+      t.assert(project.nextSprint.tasks, 'Next sprint should include array of tasks');
+      t.assert(Array.isArray(project.backlog), 'Project details should include backlog (array)');
+      t.assert(R.equals(R.pluck('id')(project.backlog), [1, 5, 3, 4, 2]), 'Backlog tasks should be in order');
     });
 });
 
 test('PUT /projects/:projectId should modify project', (t) => {
   let params = {
-    name: 'supermario'
+    name: 'supermario',
+    length: 10
   };
 
   return request(app)
-    .put('/projects/'+projectIds[0])
+    .put(`/projects/${projectIds[0]}`)
     .set('Authorization', authorization(0))
     .send(params)
     .expect(200)
@@ -114,31 +162,74 @@ test('PUT /projects/:projectId should modify project', (t) => {
       let project = res.body;
       t.pass('200 OK');
       t.equal(project.name, params.name, 'Project name should be updated');
+      t.equal(project.length, params.length, 'Project length (sprint duration) should be updated');
       t.ok(project.updatedAt, 'Project should have updatedAt property');
     });
 });
 
 test('DELETE /projects/:projectId should delete a project and respond with 204', (t) => {
-  // create a dummy project to be deleted
   return request(app)
-    .delete('/projects/'+projectIds[1])
+    .delete(`/projects/${projectIds[1]}`)
     .set('Authorization', authorization(0))
     .expect(204)
     .then((res) => {
       t.pass('204 NO CONTENT');
-      return request(app)
-        .get('/projects/'+projectIds[1])
-        .set('Authorization', authorization(0))
-        .expect(404);
+      return models.Project.findOne({where: {id: projectIds[1]}});
     })
+    .then((project) => {
+      t.notok(project, 'Project should no longer exist in database');
+    });
+});
+
+test('POST /projects/:projectId/positions should reorder the tasks in backlog', (t) => {
+  let reorder = [5, 3, 1, 4, 2]; // task ids
+  return request(app)
+    .post(`/projects/${projectIds[0]}/positions`)
+    .set('Authorization', authorization(0))
+    .send({positions: reorder})
+    .expect(200)
     .then((res) => {
-      t.pass('404 NOT FOUND - project should no longer exist in database');
+      let backlog = res.body;
+      t.pass('200 OK');
+      t.assert(R.equals(R.pluck('id')(backlog), reorder), 'Should respond with reordered tasks');
+      return models.Task.findAll({
+        where: {
+          projectId: projectIds[0],
+          sprintId: null
+        },
+        order: [['order', 'ASC']]
+      });
+    })
+    .then((tasks) => {
+      t.assert(R.equals(R.pluck('id')(tasks), reorder), 'Tasks should be reordered when fetching project details');
+    });
+});
+
+test('POST /projects/:projectId/positions should respond with 400 for invalid data params', (t) => {
+  let reorder = [1, 2, 3]; // missing task ids 4 and 5
+  return request(app)
+    .post(`/projects/${projectIds[0]}/positions`)
+    .set('Authorization', authorization(0))
+    .send({positions: reorder})
+    .expect(400)
+    .then((res) => {
+      t.pass('400 BAD REQUEST');
+      return models.Task.findAll({
+        where: {
+          projectId: projectIds[0],
+          sprintId: null
+        },
+        order: [['order', 'ASC']]
+      });
+    })
+    .then((tasks) => {
+      t.assert(R.equals(R.pluck('id')(tasks), [5, 3, 1, 4, 2]), 'Tasks order should not have changed');
     });
 });
 
 test('/projects/:projectId should respond with 405 when using wrong HTTP method', (t) => {
   return request(app)
-    .post('/projects/'+projectIds[0])
+    .post(`/projects/${projectIds[0]}`)
     .set('Authorization', authorization(0))
     .expect(405)
     .then(() => {
@@ -156,7 +247,59 @@ test('/projects should respond with 405 when using wrong HTTP method', (t) => {
     });
 });
 
-after('After', (t) => {
+test('Internal - POST /projects/:projectId/assignusers with add should add user(s) to project', (t) => {
+  let userId;
+  let params = {
+    where: {id: projectIds[0]},
+    include: [{model: models.User, as: 'users'}]
+  };
+
+  return models.User.findOne({where: {auth0Id: profile(1).user_id}})
+    .then((user) => {
+      userId = user.id;
+      return request(app)
+        .post(`/projects/${projectIds[0]}/assignusers`)
+        .set('Authorization', authorization(0))
+        .send({add: [userId]})
+        .expect(204);
+    })
+    .then(() => {
+      t.pass('204 NO CONTENT');
+      return models.Project.findOne(params);
+    })
+    .then((project) => {
+      t.equal(project.users.length, 2, 'There should be 2 users associated with the project');
+      t.assert(R.find(R.propEq('id', userId))(project.users), 'Users should include the one added');
+    });
+});
+
+test('Internal - POST /projects/:projectId/assignusers with remove should remove user(s) from project', (t) => {
+  let userId;
+  let params = {
+    where: {id: projectIds[0]},
+    include: [{model: models.User, as: 'users'}]
+  };
+
+  return models.User.findOne({where: {auth0Id: profile(0).user_id}})
+    .then((user) => {
+      userId = user.id;
+      return request(app)
+        .post(`/projects/${projectIds[0]}/assignusers`)
+        .set('Authorization', authorization(1))
+        .send({remove: [userId]})
+        .expect(204);
+    })
+    .then(() => {
+      t.pass('204 NO CONTENT');
+      return models.Project.findOne(params);
+    })
+    .then((project) => {
+      t.equal(project.users.length, 1, 'There should only be 1 user on this project');
+      t.assert(!R.find(R.propEq('id', userId))(project.users), 'The removed user should not be found');
+    });
+});
+
+after('After - Project Spec', (t) => {
   return models.sequelize.sync({
     force: true
   });

--- a/project-service/tests/userSpec.js
+++ b/project-service/tests/userSpec.js
@@ -7,7 +7,7 @@ import models from '../src/models';
 const before = test;
 const after = test;
 
-before('Before', (t) => {
+before('Before - User Spec', (t) => {
   // sync returns a promise
   return models.sequelize.sync({
     force: true
@@ -16,7 +16,8 @@ before('Before', (t) => {
     return models.User.create({
       auth0Id: profile(0).user_id,
       email: profile(0).email,
-      username: profile(0).nickname
+      username: profile(0).nickname,
+      picture: ''
     });
   });
 });
@@ -68,7 +69,7 @@ test('Public API should not create another user for the same Authorization heade
     });
 });
 
-after('After', (t) => {
+after('After - User Spec', (t) => {
   return models.sequelize.sync({
     force: true
   });

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,31 +1,34 @@
 export const projects = [
   {
-    name: 'apocalypse'
+    name: 'apocalypse',
+    emails: []
   },
   {
-    name: 'railroad'
+    name: 'railroad',
+    emails: ['bob@test.com', 'mike@test.com']
   },
   {
-    name: 'to be deleted'
+    name: 'to be deleted',
+    emails: ['mike@test.com']
   }
 ];
 
 export const sprints = [
   {
     name: 'build army',
-    status: 'In Progress',
+    status: 1,
     startDate: new Date(2015, 9, 1),
     endDate: new Date(2015, 9, 8)
   },
   {
     name: 'ravage cities',
-    status: 'Not Started',
+    status: 0,
     startDate: new Date(2015, 9, 9),
     endDate: new Date(2015, 9, 16)
   },
   {
     name: 'perform monologue',
-    status: 'Not Started',
+    status: 0,
     startDate: new Date(2015, 9, 17),
     endDate: new Date(2015, 9, 24)
   }
@@ -35,36 +38,31 @@ export const tasks = [
   {
     name: 'hire minions',
     description: 'hire incompetent goons to do biddings',
-    status: 'Ready',
-    score: 20,
-    rank: 80
+    status: 0,
+    score: 20
   },
   {
     name: 'train minions',
     description: 'give them weapons and teach them to miss',
-    status: 'Ready',
-    score: 10,
-    rank: 60
+    status: 0,
+    score: 10
   },
   {
     name: 'buy plane tickets',
     description: 'look for group discounts for larger armies (why are we flying commercial?)',
-    status: 'In Progress',
-    score: 5,
-    rank: 75
+    status: 1,
+    score: 5
   },
   {
     name: 'destroy cities',
     description: 'but all the plane tickets to populous cities are expensive...',
-    status: 'Backlog',
-    score: 100,
-    rank: 20
+    status: 0,
+    score: 100
   },
   {
     name: 'draft monologue',
     description: 'needs to be just long enough to ensure unexpected interruptions',
-    status: 'In Review',
-    score: 40,
-    rank: 40
+    status: 2,
+    score: 40
   }
 ];


### PR DESCRIPTION
Notes:
- Fetching a project's sprints only returns current (status = 1), if there is one, and next (status = 0)
- The internal API for adding/removing users is working. An array of emails should be included when creating a new project (or none if no one is invited). Right now the proj svc will match them with users, but still need to add code that sends the list to the invitation service.
- I mentioned in slack, no longer able to modify `sprintId` of a task through a PUT request. To move tasks in and out of sprints, the `projects/:projectId/sprints/:sprintId/assigntasks` endpoint needs be used. _However_, newly created tasks through `POST /projects/:projectId/tasks` can be directly assigned to a sprint by passing along `sprintId` in the data params.
- I removed the `DELETE /projects/:projectId/sprints/:sprintId` end point. What we should create eventually is an endpoint called `/sprints/cancel`, similar to `/sprints/start` and `/sprints/end`. And it would be in charge of marking the sprint as cancelled (a fourth status, in addition to 0, 1 and 2) and moving unfinished tasks to the backlog

Closes #80 
Closes #81 
Closes #82 
Closes #85 
Connects to #88 
