### PR TITLE
Create task button in sprint view + improved styling

### DIFF
--- a/frontend/src/actions/actions.js
+++ b/frontend/src/actions/actions.js
@@ -7,6 +7,7 @@ export const DashboardActions = Reflux.createActions({
 });
 
 export const SprintActions = Reflux.createActions({
+  'openCreateTask': {},
   'fetchSprint': {asyncResult: true},
   'updateTaskStatusLocally': {},
   'updateTaskStatusOnServer': {asyncResult: true},

--- a/frontend/src/components/app.jsx
+++ b/frontend/src/components/app.jsx
@@ -5,6 +5,7 @@ import {Navbar, Nav, NavItem, CollapsibleNav} from 'react-bootstrap';
 import auth from '../auth/auth.js';
 import AppStore from '../stores/appStore.js';
 import Notifications from './notifications/notifications.jsx';
+import {SprintActions} from '../actions/actions.js';
 
 let RouteHandler = Router.RouteHandler;
 
@@ -43,6 +44,18 @@ let App = React.createClass({
       }
     };
 
+    let createTask = () => {
+      if (this.isActive('sprint')) {
+        return (
+          <li>
+            <div className='btn-container nav-button'>
+              <button className='btn primary' onClick={SprintActions.openCreateTask}>+ New Task</button>
+            </div>
+          </li>
+        );
+      }
+    };
+
     let authNav = () => {
       if (this.state.isLoggedIn) {
         return (<NavItem onClick={auth().logout}>Sign out</NavItem>);
@@ -57,6 +70,7 @@ let App = React.createClass({
             <Nav navbar>
               <NavItem onClick={this.goToDashboard}>Dashboard</NavItem>
               {project()}
+              {createTask()}
             </Nav>
             <Nav navbar right>{authNav()}</Nav>
           </CollapsibleNav>

--- a/frontend/src/components/app.jsx
+++ b/frontend/src/components/app.jsx
@@ -65,7 +65,7 @@ let App = React.createClass({
 
     return (
       <div className='app'>
-        <Navbar brand='Turtle' inverse toggleNavKey={0}>
+        <Navbar brand='Turtle' fixedTop inverse toggleNavKey={0}>
           <CollapsibleNav eventKey={0}>
             <Nav navbar>
               <NavItem onClick={this.goToDashboard}>Dashboard</NavItem>

--- a/frontend/src/components/project/backlog.jsx
+++ b/frontend/src/components/project/backlog.jsx
@@ -29,11 +29,11 @@ let Backlog = React.createClass({
     return (
       <div className='backlog'>
         <CreateTask
-            showModal={this.state.showModal}
-            project={this.props.project}
-            close={this.close}
-            users={this.props.users}
-          />
+          showModal={this.state.showModal}
+          project={this.props.project}
+          close={this.close}
+          users={this.props.users}
+        />
         <h1 className='left'>Backlog</h1>
         <div className='btn-container right'>
           <button className='btn primary' onClick={this.open}>+ New Task</button>

--- a/frontend/src/components/project/project.css
+++ b/frontend/src/components/project/project.css
@@ -12,6 +12,17 @@ hr {
   min-height: 200px;
 }
 
+.task-container {
+  max-height: 600px;
+  overflow-y: auto;
+  padding: 10px;
+  .task {
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 .days-left {
   font-size: 16px;
 }

--- a/frontend/src/components/sprintboard/board.jsx
+++ b/frontend/src/components/sprintboard/board.jsx
@@ -8,19 +8,20 @@ import {DragDropContext} from 'react-dnd';
 import HTML5Backend from 'react-dnd/modules/backends/HTML5';
 
 import SprintColumn from './column.jsx';
+import CreateTask from '../tasks/createTask.jsx';
 
 let SprintBoard = React.createClass({
-  mixins: [
-    Reflux.ListenerMixin
-  ],
+  mixins: [Reflux.ListenerMixin],
 
   getInitialState() {
     return {
       id: parseInt(this.props.params.id),
+      users: [],
       sprint: {
         columns: [],
         tasksByColumn: {}
-      }
+      },
+      showModal: false
     };
   },
 
@@ -29,28 +30,38 @@ let SprintBoard = React.createClass({
     SprintActions.fetchSprint(this.state.id);
   },
 
-  onStoreUpdate(sprint) {
-    this.setState({
-      sprint: sprint
-    });
+  onStoreUpdate(data) {
+    this.setState(data);
+  },
+
+  close() {
+    this.setState({showModal: false});
+    SprintActions.fetchSprint(this.state.id);
   },
 
   render() {
-    let sprintColumns = [];
-    _.forEach(this.state.sprint.columns, (column, key) => {
+    let sprintColumns = _.map(this.state.sprint.columns, (column, key) => {
       let columnTasks = this.state.sprint.tasksByColumn[key];
-      sprintColumns.push(
+      return (
         <SprintColumn
           key={column}
           id={key}
           columnName={column}
           tasks={columnTasks}
+          users={this.state.users}
         />
       );
     });
 
     return (
       <div className='sprint-board'>
+        <CreateTask
+          showModal={this.state.showModal}
+          project={this.state.id}
+          close={this.close}
+          users={this.state.users}
+          sprint={this.state.sprint.id}
+        />
         {sprintColumns}
       </div>
     );

--- a/frontend/src/components/sprintboard/column.jsx
+++ b/frontend/src/components/sprintboard/column.jsx
@@ -65,8 +65,10 @@ let SprintColumn = React.createClass({
     const {connectDropTarget} = this.props;
     return connectDropTarget(
       <div className='sprint-column'>
-        <p className='column-name'>{this.props.columnName}</p>
-        {tasks}
+        <div className='column-name'>{this.props.columnName}</div>
+        <div className='column-tasks'>
+          {tasks}
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/sprintboard/column.jsx
+++ b/frontend/src/components/sprintboard/column.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import {DropTarget} from 'react-dnd';
 import {SprintActions} from '../../actions/actions';
@@ -37,9 +38,16 @@ let collect = (connect, monitor) => {
 
 let SprintColumn = React.createClass({
 
+  propTypes: {
+    users: React.PropTypes.array.isRequired,
+    tasks: React.PropTypes.array.isRequired
+  },
+
   render() {
     let tasks = this.props.tasks || [];
+
     tasks = tasks.map((task) => {
+      let user = _.findWhere(this.props.users, {id: task.userId});
       return (
         <Task
           key={task.id}
@@ -48,7 +56,7 @@ let SprintColumn = React.createClass({
           description={task.description}
           score={task.score}
           status={task.status}
-          user={task.user}
+          user={user}
           isOnSprintboard={true}
         />
       );

--- a/frontend/src/components/sprintboard/sprintboard.css
+++ b/frontend/src/components/sprintboard/sprintboard.css
@@ -8,20 +8,37 @@
   display: inline-block;
   vertical-align: top;
   width: 25%;
-  padding: 0 5px;
   height: 100%;
   text-align: center;
-  border-left: solid #AAA 2px;
   border-right: solid #AAA 2px;
+  overflow-y: auto;
+}
+
+.sprint-column:last-child {
+  border-right: none;
 }
 
 .column-name {
-  font-size: 18px;
-  padding: 10px;
+  font-size: 20px;
+  padding: 12px;
   margin: 0;
+  position: fixed;
+  width: 25%;
+  height: 40px;
+  background-color: #EEE;
+  border-right: solid #AAA 2px;
+  z-index: 50;
 }
 
-.sprint-column .task {
+.sprint-column:last-child .column-name {
+  border-right: none;
+}
+
+.column-tasks {
+  margin-top: 60px;
+}
+
+.column-tasks .task {
   width: 90%;
   margin-left: auto;
   margin-right: auto;

--- a/frontend/src/components/tasks/createTask.jsx
+++ b/frontend/src/components/tasks/createTask.jsx
@@ -13,7 +13,7 @@ let CreateTask = React.createClass({
     showModal: React.PropTypes.bool.isRequired,
     close: React.PropTypes.func.isRequired,
     users: React.PropTypes.array.isRequired,
-    sprintId: React.PropTypes.number // defaults to null
+    sprint: React.PropTypes.number // defaults to null
   },
 
   getInitialState() {
@@ -23,8 +23,7 @@ let CreateTask = React.createClass({
         name: '',
         description: '',
         score: 1,
-        userId: null,
-        sprintId: this.props.sprintId || null
+        userId: null
       }
     };
   },
@@ -40,16 +39,16 @@ let CreateTask = React.createClass({
   },
 
   createTask() {
-    ProjectActions.createTask(this.props.project, this.state.taskProperties);
+    let taskProperties = _.extend({sprintId: this.props.sprint}, this.state.taskProperties);
+    ProjectActions.createTask(this.props.project, taskProperties);
   },
 
   handleChanges(e) {
     let newProperties = _.extend({}, this.state.taskProperties);
     newProperties.name = React.findDOMNode(this.refs.taskName).value;
     newProperties.description = React.findDOMNode(this.refs.taskDescription).value;
-    // uncomment when ready, or else task will not be accepted by project svc
-    // newProperties.userId = parseInt(this.refs.taskAssignment.getValue()) || null;
-    newProperties.score = Math.max(1, React.findDOMNode(this.refs.taskScore).value);
+    newProperties.userId = parseInt(this.refs.taskAssignment.getValue()) || null;
+    newProperties.score = Math.min(999, Math.max(1, React.findDOMNode(this.refs.taskScore).value));
 
     this.setState({
       taskProperties: newProperties,

--- a/frontend/src/stores/createTaskStore.js
+++ b/frontend/src/stores/createTaskStore.js
@@ -7,7 +7,7 @@ let CreateTaskStore = Reflux.createStore({
   listenables: ProjectActions,
 
   onCreateTask(id, properties) {
-    projects.id(id).tasks.create(_.pick(properties, 'name', 'score', 'description')).then((response) => {
+    projects.id(id).tasks.create(_.pick(properties, 'name', 'score', 'description', 'userId', 'sprintId')).then((response) => {
       this.trigger(response);
     });
   }

--- a/frontend/src/stores/sprintStore.js
+++ b/frontend/src/stores/sprintStore.js
@@ -8,12 +8,22 @@ const SprintStore = Reflux.createStore({
 
   columns: ['To Do', 'In Progress', 'Review', 'Done'],
 
+  onOpenCreateTask() {
+    this.trigger({
+      showModal: true
+    });
+  },
+
   onFetchSprint(id) {
     projects.id(id).fetch().then((project) => {
+      let users = project.users;
       let sprint = project.currentSprint;
       this.transformSprint(sprint);
       this.sprint = sprint; // cache sprint locally
-      this.trigger(this.sprint);
+      this.trigger({
+        users,
+        sprint: this.sprint
+      });
     });
   },
 
@@ -36,7 +46,7 @@ const SprintStore = Reflux.createStore({
     if (task) {
       oldColumn.splice(oldColumn.indexOf(task), 1);
       newColumn.push(task);
-      this.trigger(sprint);
+      this.trigger({sprint});
     }
   },
 
@@ -55,7 +65,7 @@ const SprintStore = Reflux.createStore({
     let targetTaskContainer = targetTaskInfo.container;
     draggedTaskContainer.splice(draggedTaskContainer.indexOf(draggedTask), 1);
     targetTaskContainer.splice(targetTaskContainer.indexOf(targetTask), 0, draggedTask);
-    this.trigger(this.sprint);
+    this.trigger({sprint: this.sprint});
   },
 
   onReorderTasksOnServer() {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -14,6 +14,7 @@ html, body {
 
 .app {
   height: 100%;
+  padding-top: 50px;
 }
 
 .navbar {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -78,6 +78,11 @@ textarea {
   border-radius: 4px;
 }
 
+.nav-button {
+  margin-left: 12px;
+  padding-top: 7px;
+}
+
 /* bootstrap modals */
 .modal-header {
   text-align: center;

--- a/frontend/tests/sprintboard/boardSpec.js
+++ b/frontend/tests/sprintboard/boardSpec.js
@@ -6,10 +6,12 @@ import {__RewireAPI__ as testmodule} from '../../src/components/sprintboard/boar
 let SprintBoard =  testmodule.__GetDependency__('SprintBoard');
 SprintBoard.prototype.getInitialState = () => {
   return {
+    users: [],
     sprint: {
       columns: ['To Do', 'In Progress', 'Review', 'Done'],
       tasksByColumn: {}
-    }
+    },
+    showModal: false
   };
 };
 
@@ -28,7 +30,7 @@ test('Sprint board is a div', (assert) => {
 
 test('Sprint board has a class "sprint-board"', (assert) => {
   assert.equal(sprintBoard.props.className, 'sprint-board',
-    'Sprint board should have a class "sprintBoard"');
+    'Sprint board should have a class "sprint-board"');
   assert.end();
 });
 
@@ -36,7 +38,6 @@ test('Sprint board renders the correct number of columns', (assert) => {
   // this is a pretty stupid test, because I can not assign
   // an arbtrary number of columns during the test; it currently checks
   // that the number of columns is the same as in src/mock-data/sprint-columns.js file
-  assert.equal(sprintBoard.props.children.length, 4,
-    'Sprint board should render four sprint columns');
+  assert.equal(sprintBoard.props.children[1].length, 4, 'Sprint board should render four sprint columns');
   assert.end();
 });


### PR DESCRIPTION
![screen shot 2015-09-14 at 11 05 19 am](https://cloud.githubusercontent.com/assets/10968717/9857645/8a1aa33c-5ad0-11e5-9b7a-fba76334b23d.png)
![screen shot 2015-09-14 at 11 05 08 am](https://cloud.githubusercontent.com/assets/10968717/9857643/8a02d900-5ad0-11e5-8bf0-4bcfde9d3d5b.png)
### Create Task in Sprint View
- Modified `sprintStore` to also trigger `users` and `showModal` (boolean) instead of just `sprint` data
- I saw two ways to add the button that would trigger the modal and went with option 2 (that way it actually gets collapsed into the dropdown along with the other items nicely).
  1. Add it in sprint view, but use CSS absolute positioning to move it in the nav bar
  2. Add it in the nav bar in app.jsx, and have it initiate an action `SprintActions.openCreateTask`
- Fixed issue in sprint board where user picture was not showing up on assigned tasks
### Styling
- I made it scrollable in sprint columns and in the project view task containers once you have too many tasks.
- I think we should consider redoing our layout of the project view. There really is no reason to be scrolling down a page after adding just ~6 tasks when we have so much white space on the page. The more scrollng around, the harder it is to drag tasks between two spots, so we should take that into consideration too. Maybe the entire backlog can occupy the left half and current/next sprint occupy the right. Instead of stacking everything on top of each other.

Closes #102 
