### PR TITLE
Add styling, edits to project service

### DIFF
--- a/frontend/src/components/dashboard/createProject.css
+++ b/frontend/src/components/dashboard/createProject.css
@@ -30,7 +30,7 @@
     list-style-type: none;
     clear:both;
     overflow: auto;
-    margin: 4px 0;
+    margin: 8px 0;
     line-height: 30px;
     .email {
       float: left;

--- a/frontend/src/components/dashboard/createProject.jsx
+++ b/frontend/src/components/dashboard/createProject.jsx
@@ -1,22 +1,17 @@
 import React from 'react';
-import {Modal, Input} from 'react-bootstrap';
+import {Modal, Input, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import Member from './member.jsx';
 import {DashboardActions as Actions} from '../../actions/actions.js';
 
 let CreateProject = React.createClass({
   getInitialState() {
     return {
+      projectName: '',
       invitees: [],
       inviteeEmail: '',
       disableInvite: true,
       disableCreate: true
     };
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    if (!prevProps.showModal && this.props.showModal) {
-      React.findDOMNode(this.refs.projectName).focus();
-    }
   },
 
   checkEmail(e) {
@@ -48,7 +43,10 @@ let CreateProject = React.createClass({
   },
 
   checkName(e) {
-    this.setState({disableCreate: !e.target.value});
+    this.setState({
+      disableCreate: !e.target.value,
+      projectName: e.target.value.substr(0, 40)
+    });
   },
 
   createProject() {
@@ -95,21 +93,28 @@ let CreateProject = React.createClass({
       </button>
     );
 
+    let letterCount = (
+      <Tooltip id='project-letter-count'>{40 - this.state.projectName.length}</Tooltip>
+    );
+
     return (
-      <Modal show={this.props.showModal} onHide={this.close} bsSize='md'>
+      <Modal show={this.props.showModal} onHide={this.close} dialogClassName='modal-create-project'>
         <Modal.Header closeButton>
           <Modal.Title>Create a New Project</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
           <div className='create-project'>
-            <input
-              type='text'
-              className='name'
-              ref='projectName'
-              placeholder='Title'
-              onChange={this.checkName}
-            />
+            <OverlayTrigger trigger='focus' placement='right' overlay={letterCount}>
+              <input
+                type='text'
+                className='name'
+                ref='projectName'
+                placeholder='Title'
+                onChange={this.checkName}
+                value={this.state.projectName}
+              />
+            </OverlayTrigger>
 
             <label className='team'>Team Members</label>
             <form>

--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -19,16 +19,23 @@
   margin: 20px;
   position: relative;
   transition: all 0.15s ease-in-out;
+  word-break: break-word;
   .name {
     display: inline-block;
     line-height: 28px;
     vertical-align: middle;
   }
   .close {
-    top: 8px;
-    right: 13px;
+    top: 2px;
+    right: 8px;
     position: absolute;
     display: none;
+    text-shadow: none;
+    font-size: 30px;
+  }
+  .close:focus,
+  .close:active {
+    outline: none;
   }
 }
 
@@ -55,4 +62,28 @@
   color: #777;
   background-color: #F8F8F8;
   border-color: #999;
+}
+
+.project-enter {
+  opacity: 0.01;
+  transform: scale(0.01, 0.01);
+}
+
+.project-enter.project-enter-active {
+  opacity: 1;
+  transform: scale(1.0, 1.0);
+  transition: all .25s ease-in;
+}
+
+.project-leave {
+  opacity: 1;
+}
+
+.project-leave.project-leave-active {
+  opacity: 0.01;
+  transition: all .25s ease-in;
+}
+
+.modal-create-project {
+  width: 400px;
 }

--- a/frontend/src/components/dashboard/dashboard.jsx
+++ b/frontend/src/components/dashboard/dashboard.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React from 'react/addons';
 import {Navigation} from 'react-router';
 import Reflux from 'reflux';
 import Item from './item.jsx';
 import CreateProject from './createProject.jsx';
 import {DashboardActions} from '../../actions/actions';
 import DashboardStore from '../../stores/dashboardStore';
+
+let ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 let Dashboard = React.createClass({
   // `ListenerMixin` will unsubscribe components from stores upon unmounting
@@ -49,11 +51,21 @@ let Dashboard = React.createClass({
 
         <ul>
           <Item id='0' name='+ New Project' click={this.open} isCreateProject='true'/>
-          {
-            this.state.projects.map((project) => {
-              return <Item key={project.id} id={project.id} name={project.name} click={this.enterProject} delete={this.deleteProject} />;
-            })
-          }
+          <ReactCSSTransitionGroup transitionName='project'>
+            {
+              this.state.projects.map((project) => {
+                return (
+                  <Item
+                    key={project.id}
+                    id={project.id}
+                    name={project.name}
+                    click={this.enterProject}
+                    delete={this.deleteProject}
+                  />
+                );
+              })
+            }
+          </ReactCSSTransitionGroup>
         </ul>
       </div>
     );

--- a/frontend/src/components/dashboard/item.jsx
+++ b/frontend/src/components/dashboard/item.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import {Glyphicon} from 'react-bootstrap';
+import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 let Item = React.createClass({
 
@@ -16,13 +16,19 @@ let Item = React.createClass({
   },
 
   render() {
+    let deleteTooltip = (
+      <Tooltip id='tip-delete'><strong>Permanently</strong> Delete Project</Tooltip>
+    );
+
     let classes = classNames({
       'item': true,
       'new-project': this.props.isCreateProject
     });
     return (
       <li className={classes} onClick={this.handleClick}>
-        <button className='close' onClick={this.deleteProject}><Glyphicon glyph='remove' /></button>
+        <OverlayTrigger rootClose placement='top' overlay={deleteTooltip}>
+          <button className='close' onClick={this.deleteProject}>&times;</button>
+        </OverlayTrigger>
         <p className='name'>{this.props.name}</p>
       </li>
     );

--- a/frontend/src/components/tasks/task.jsx
+++ b/frontend/src/components/tasks/task.jsx
@@ -62,7 +62,7 @@ let Task = React.createClass({
       description: this.props.description,
       score: this.props.score,
       sprintId: this.props.sprintId,
-      userId: this.props.user ? this.props.user : null
+      userId: this.props.user ? this.props.user.id : null
     });
   },
 

--- a/frontend/src/components/tasks/taskForm.css
+++ b/frontend/src/components/tasks/taskForm.css
@@ -1,3 +1,7 @@
+.modal-create-task {
+  width: 360px;
+}
+
 .create-task {
   .name {
     width: 100%;
@@ -20,6 +24,7 @@
     width: 50px;
     float: right;
     margin: 10px 0;
+    padding-right: 0;
     input {
       margin: 0;
     }

--- a/frontend/src/components/tasks/taskForm.jsx
+++ b/frontend/src/components/tasks/taskForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import Router from 'react-router';
 import _ from 'lodash';
-import {Modal, Input} from 'react-bootstrap';
+import {Modal, Input, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {ProjectActions, SprintActions, TaskFormActions} from '../../actions/actions';
 import TaskFormStore from '../../stores/taskFormStore';
 
@@ -78,7 +78,7 @@ let TaskForm = React.createClass({
 
   handleChanges(e) {
     let newProperties = _.extend({}, this.state.taskProperties);
-    newProperties.name = React.findDOMNode(this.refs.taskName).value;
+    newProperties.name = React.findDOMNode(this.refs.taskName).value.substr(0, 255);
     newProperties.description = React.findDOMNode(this.refs.taskDescription).value;
     newProperties.userId = parseInt(this.refs.taskAssignment.getValue()) || null;
     newProperties.score = Math.min(999, Math.max(1, React.findDOMNode(this.refs.taskScore).value));
@@ -151,14 +151,23 @@ let TaskForm = React.createClass({
       );
     };
 
+    let letterCount = (
+      <Tooltip id='task-letter-count'>{255 - this.state.taskProperties.name.length}</Tooltip>
+    );
+
+    let scoreTooltip = (
+      <Tooltip id='tip-score'>Number between 1 - 999</Tooltip>
+    );
+
     return (
-      <Modal show={this.state.show} onHide={this.close} bsSize='sm'>
+      <Modal show={this.state.show} onHide={this.close} dialogClassName='modal-create-task'>
         <Modal.Header closeButton>
           <Modal.Title>Create a New Task</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
           <form className='create-task'>
+            <OverlayTrigger trigger='focus' placement='right' overlay={letterCount}>
             <input
               type='text'
               className='name'
@@ -167,6 +176,7 @@ let TaskForm = React.createClass({
               onChange={this.handleChanges}
               value={this.state.taskProperties.name}
             />
+            </OverlayTrigger>
 
             <textarea
               className='description'
@@ -196,14 +206,16 @@ let TaskForm = React.createClass({
 
             <div className='score'>
               <label>Score:</label>
-              <input
-                type='number'
-                className='score'
-                ref='taskScore'
-                min='1'
-                onChange={this.handleChanges}
-                value={this.state.taskProperties.score}
-              />
+              <OverlayTrigger placement='right' overlay={scoreTooltip}>
+                <input
+                  type='number'
+                  className='score'
+                  ref='taskScore'
+                  min='1'
+                  onChange={this.handleChanges}
+                  value={this.state.taskProperties.score}
+                />
+              </OverlayTrigger>
             </div>
           </form>
         </Modal.Body>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -143,5 +143,5 @@ textarea {
 @import "components/dashboard/dashboard.css";
 @import "components/dashboard/createProject.css";
 @import "components/tasks/task.css";
-@import "components/tasks/createTask.css";
+@import "components/tasks/taskForm.css";
 @import "components/notifications/notification.css";

--- a/project-service/docs/api.md
+++ b/project-service/docs/api.md
@@ -332,7 +332,7 @@ Delete an existing project. **All sprints and tasks for the project are also del
 <a name="external-projects-positions">
 ### Reorder Backlog Tasks
 
-Reorder the tasks in the project backlog by attaching an array of task IDs that represent the tasks' relative ranking. All tasks in the backlog need to be present in the `positions` array. Task IDs that do not correspond to tasks in the project backlog are ignored.
+Reposition a task to a certain index in the backlog. `index = 0` means positioning the task first.
 
 - **URL**
   + `/projects/:projectId/positions`
@@ -341,7 +341,8 @@ Reorder the tasks in the project backlog by attaching an array of task IDs that 
 - **Query Params**
   + None
 - **Data Params**
-  + `positions=[array]`
+  + `id=[number]`
+  + `index=[number]`
 - **Success Response**
   + Code: `200 OK`
   + Content:
@@ -632,7 +633,7 @@ Edit an existing sprint. The name cannot be empty.
 <a name="external-sprints-positions">
 ### Reorder Tasks in a Sprint
 
-Reorder the tasks in the sprintboard by attaching an array of task IDs that represents the tasks' relative ranking. Task IDs that do not correspond to tasks in this sprint are ignored.
+Reorder the tasks in the sprintboard by providing the tasks's `id` and the new `index` of the task. An `index` of 0 represents highest priority/ordered first.
 
 - **URL**
   + `/projects/:projectId/sprints/:sprintId/positions`
@@ -641,7 +642,8 @@ Reorder the tasks in the sprintboard by attaching an array of task IDs that repr
 - **Query Params**
   + None
 - **Data Params**
-  + `positions=[array]`
+  + `id=[number]`
+  + `index=[number]`
 - **Success Response**
   + Code: `200 OK`
   + Content:

--- a/project-service/docs/events.md
+++ b/project-service/docs/events.md
@@ -16,10 +16,12 @@ The name of the events will be further namespaced, such as `project:change`, `ta
 - [Sprints](#sprints)
   + [Start](#sprints-start)
   + [End](#sprints-end)
+  + [Assign](#sprints-assign)
 - [Tasks](#tasks)
   + [Add](#tasks-add)
   + [Change](#tasks-change)
   + [Delete](#tasks-delete)
+  + [Reorder](#tasks-reorder)
 
 <a name="projects"/>
 ## Projects
@@ -155,6 +157,35 @@ When a sprint is ended for the current project.
 }
 ```
 
+<a name="sprints-assign"/>
+### Assign
+
+Event when tasks are assigned or removed from a sprint. The `add` array contains task ids for tasks that were assigned to the sprint (`sprintId`). The `remove` array contains taks ids for tasks that were removed from the sprint (`sprintId`) to the project backlog.
+
+- **Event Name**
+  + `sprint:assign`
+- **Data Parameters**
+  + `add=[array]`
+  + `remove=[array]`
+  + `sprintId=[number]`
+  + `projectId=[number]`
+  + `initiator=[number]`
+  + `message=[string]`
+
+```json
+{
+  "event": "sprint:assign",
+  "data": {
+    "add": [1, 2, 3],
+    "remove": [],
+    "sprintId": 1,
+    "projectId": 1,
+    "initiator": 1,
+    "message": "Bojack has assigned tasks to the upcoming sprint."
+  }
+}
+```
+
 <a name="tasks"/>
 ## Tasks
 
@@ -254,9 +285,44 @@ Task deleted from current project. The payload will also include a `initiator` t
   "event": "task:delete",
   "data": {
     "id": 1,
+    "sprintId": 2,
     "projectId": 1,
     "initiator": 1,
     "message": "Bojack deleted a task from project Awesome Project."
+  }
+}
+```
+
+<a name="tasks-reorder"/>
+### Reorder
+
+Tasks got reordered in backlog or in a sprint. The payload will include an array of ids that represent the new order of the tasks.
+
+- **Event Name**
+  + `task:reorder`
+- **Data Parameters**
+  + Always
+    * `id=[number]`
+    * `status=[number]`
+    * `oldIndex=[number]`
+    * `newIndex=[number]`
+    * `sprintId=[number]`
+    * `projectId=[number]`
+    * `initiator=[number]`
+    * `message=[string]`
+
+```json
+{
+  "event": "task:reorder",
+  "data": {
+    "id": 1,
+    "status": 2,
+    "oldIndex": 0,
+    "newIndex": 3,
+    "sprintId": null,
+    "projectId": 1,
+    "initiator": 1,
+    "message": "Bojack reordered a task in the backlog."
   }
 }
 ```

--- a/project-service/src/models/project.js
+++ b/project-service/src/models/project.js
@@ -1,7 +1,7 @@
 export default (sequelize, DataTypes) => {
   let Project = sequelize.define('Project', {
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(40),
       validate: {
         notEmpty: true
       }

--- a/project-service/src/models/task.js
+++ b/project-service/src/models/task.js
@@ -7,7 +7,7 @@ export default (sequelize, DataTypes) => {
       }
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       defaultValue: ''
     },
     status: {

--- a/project-service/src/routes/projects.js
+++ b/project-service/src/routes/projects.js
@@ -193,44 +193,48 @@ router.delete('/:projectId', (req, res, next) => {
 /* === /projects/:projectId/positions === */
 
 router.post('/:projectId/positions', (req, res, next) => {
-  if (!Array.isArray(req.body.positions)) {
+  if (!(req.body.id && req.body.index >= 0)) {
     return res.status(400).json(msg.project[400]);
   }
 
   // fetch all backlog tasks
   req.project.getTasks({where: {sprintId: null}})
     .then((tasks) => {
-      // create tasks hash
-      let tasksHash = tasks.reduce((hash, task) => {
-        hash[task.id] = task;
-        return hash;
-      }, {});
+      tasks = tasks.sort((a, b) => {
+        return a.getDataValue('order') - b.getDataValue('order');
+      });
 
-      // create positions hash -
-      // - the order to be assigned to the task is the index + 1
-      // - only add to hash if the id corresponds to an existing task
-      let posHash = req.body.positions.reduce((hash, id, idx) => {
-        if (tasksHash[id]) {
-          hash[id] = idx + 1;
-        }
-        return hash;
-      }, {});
+      let oldIndex = R.findIndex(R.propEq('id', req.body.id))(tasks);
+      let newIndex = Math.min(req.body.index, tasks.length - 1);
 
-      // both hashes should have the same number of tasks, otherwise it means
-      // the `positions` array did not have all the backlog tasks
-      if (Object.keys(tasksHash).length !== Object.keys(posHash).length) {
+      if (oldIndex === -1) { // if task id does not exist, send 400
         return res.status(400).json(msg.project[400]);
       }
 
+      let target = tasks.splice(oldIndex, 1)[0]; // extract the task
+      tasks.splice(newIndex, 0, target); // insert it at desired index
+
       // update each task's `order` and send success response
-      Promise.all(req.body.positions.map((id) => {
-        return tasksHash[id].update({order: posHash[id]});
+      Promise.all(tasks.map((task, idx) => {
+        return task.update({order: idx + 1});
       }))
       .then((tasks) => {
         let data = R.pluck('dataValues')(tasks).sort((a, b) => {
           return a.order - b.order;
         });
         res.status(200).json(data);
+
+        // publish
+        publish('task:reorder', req.project.acl, {
+          id: target.id,
+          status: target.status,
+          oldIndex,
+          newIndex,
+          sprintId: null,
+          projectId: req.project.id,
+          initiator: req.user.model.id,
+          message: `${req.user.model.username} reordered a task in the backlog.`
+        });
       });
     });
 });

--- a/project-service/src/routes/tasks.js
+++ b/project-service/src/routes/tasks.js
@@ -204,6 +204,8 @@ router.delete('/:taskId', (req, res, next) => {
 
       // publish
       publish('task:delete', req.project.acl, {
+        id: req.task.id,
+        sprintId: req.task.sprintId,
         projectId: req.project.id,
         initiator: req.user.model.id,
         message: `${req.user.model.username} deleted a task from project ${req.project.name}`

--- a/project-service/tests/taskSpec.js
+++ b/project-service/tests/taskSpec.js
@@ -99,6 +99,7 @@ test('POST /project/:projectId/tasks should create a new task', (t) => {
       t.equal(task.name, testTasks[3].name, 'Task name should match');
       t.equal(task.order, 1, 'Task should haver order = 1 (first task added in backlog)');
 
+      t.comment('Event publication tests');
       let args = spy.args[0];
       let event = args[0];
       let acl = args[1];
@@ -196,6 +197,7 @@ test('PUT /project/:projectId/tasks/:taskId should modify task', (t) => {
 
       t.assert(match, 'Parameters should match');
 
+      t.comment('Event publication tests');
       let args = spy.args[0];
       let event = args[0];
       let acl = args[1];
@@ -239,13 +241,16 @@ test('DELETE /project/:projectId/tasks/:taskId should delete a task and respond 
     .then((task) => {
       t.notok(task, 'Task should no longer exist');
 
+      t.comment('Event publication tests');
       let args = spy.args[0];
       let event = args[0];
       let acl = args[1];
       let data = args[2];
       t.equal(event, 'task:delete', 'Event task:delete should be published');
       t.ok(acl.length, 'ACL should include at least 1 user');
+      t.ok(data.id, 'Payload should include the task id');
       t.ok(data.initiator, 'Payload should include the initiator');
+      t.ok(data.sprintId, 'Payload should include sprint Id');
       t.ok(data.projectId, 'Payload should include project Id');
       t.ok(data.message, 'Payload should have a message');
     });


### PR DESCRIPTION
### DB Schema
- I changed task description to `TEXT`, and limited the characters for project title to 40.
### Styling
- Adjusted size of create project and create task modals
- Some animation for creating.deleting projects
- Fixed a bug where the "edit task" modal wasn't populated with the assigned user information
  ![animatedv2](https://cloud.githubusercontent.com/assets/10968717/9891910/c8008ccc-5bbe-11e5-9ceb-0e3aface9943.gif)
### Repositioning endpoint
- Now accepts task `id` and new `index` and repositions accordingly
- Sends this information along in `task:reorder` event
- Updated docs accordingly
