### PR TITLE
Bugfix

### DIFF
--- a/frontend/src/stores/projectStore.js
+++ b/frontend/src/stores/projectStore.js
@@ -11,6 +11,7 @@ const ProjectStore = Reflux.createStore({
       this.registerEventHandlers(id);
     }
     projects.id(id).fetch().then((project) => {
+      console.log(project);
       if (project.currentSprint) {
         let sortedSprint = [];
         _.each(project.currentSprint.tasks, (task) => {
@@ -43,7 +44,7 @@ const ProjectStore = Reflux.createStore({
       let task = this.findTask(event.id);
       let oldStatus = task.status;
       _.extend(task, _.pick(event, 'name', 'score', 'description', 'userId', 'sprintId', 'status'));
-      if (task.status === oldStatus) {
+      if (task.status === oldStatus) { // if not equal, changes will be made on `reorder` event
         this.trigger(this.project);
       }
     });

--- a/frontend/src/stores/sprintStore.js
+++ b/frontend/src/stores/sprintStore.js
@@ -55,7 +55,6 @@ const SprintStore = Reflux.createStore({
       return projects.id(this.project.id).tasks.id(task.id).update({status: newStatus}).then(resolve);
     })
     .then(() => {
-      console.log('reordering 123');
       let tasks = _.flatten(this.sprint.tasksByColumn);
       let ids = _.pluck(tasks, 'id');
       let index = _.indexOf(ids, taskId);


### PR DESCRIPTION
- Fixed missing tasks (this was due to browsersync firing two `/start` requests on "start sprint", which resulted in creating two new sprints with `status = 0`). Fixed this by adding a processing status that kept track for each project id. So if a `/start` request is sent for a project that is already processing a `/start`, it would just respond with 200 and say it's already processing
- Fixed drag issue in project view, this was due to `sprintId` not being set on the frontend on the `assign` event
